### PR TITLE
Apenas uma pequea correção em uma palavra que estava com erro

### DIFF
--- a/pt_BR/appendices/about.xml
+++ b/pt_BR/appendices/about.xml
@@ -360,7 +360,7 @@ Retorna o tamanho de uma dada string.
    linkend="about.notes">'Sobre as notas de usuários'</link>.
   </para>
   <para>
-   O manual PHP é traduzindo em várias línguas. Sabendo Inglês e uma língua
+   O manual PHP é traduzido em várias línguas. Sabendo Inglês e uma língua
    estrangeira permite uma maneira de ajudar a melhorar o manual PHP
    trabalhando com um time de tradução. Para mais informações sobre como iniciar
    uma nova tradução, ou ajudar no projeto de tradução atual, por favor leia


### PR DESCRIPTION
Correção da frase "O manual PHP é **traduzindo** em várias línguas." para "O manual PHP é **traduzido** em várias línguas. "