### PR TITLE
Corrigindo a palavra "pessados" para "pesados"

### DIFF
--- a/pt_BR/install/fpm/index.xml
+++ b/pt_BR/install/fpm/index.xml
@@ -4,7 +4,7 @@
    <title>FastCGI Process Manager (FPM)</title>
    <para>
     FPM (FastCGI Process Manager) é uma alternativa para a implementação PHP FastCGI
-    com algumas features adicionais (principalmente) usado em sites pessados.
+    com algumas features adicionais (principalmente) usado em sites pesados.
    </para>
    <para>
     Entre as features estão incluidas:


### PR DESCRIPTION
Colocando a palavra "pesado" no lugar de "pessados" na frase "FPM (FastCGI Process Manager) é uma alternativa para a implementação PHP FastCGI com algumas features adicionais (principalmente) usado em sites pessados."