### PR TITLE
Correção no exemplo da função array_fill()

### DIFF
--- a/pt_BR/reference/array/functions/array-fill.xml
+++ b/pt_BR/reference/array/functions/array-fill.xml
@@ -115,7 +115,7 @@
 <![CDATA[
 <?php
 $a = array_fill(5, 6, 'banana');
-$b = array_fill(-2, 2, 'pear');
+$b = array_fill(-2, 4, 'pear');
 print_r($a);
 print_r($b);
 ?>


### PR DESCRIPTION
Para que o retorno do exemplo fique correto, int $num deve ser 4