### PR TITLE
Atualização das traduções antigas de reference/session/*.xml

### DIFF
--- a/pt_BR/reference/session/book.xml
+++ b/pt_BR/reference/session/book.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
-<!-- Membership: core -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 333618 Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
 
 <book xml:id="book.session" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="core" ?>
  <title>Manipulação de Sessão</title>
  <titleabbrev>Sessões</titleabbrev>
 
@@ -11,61 +11,74 @@
   &reftitle.intro;
   <para>
    O suporte a sessões no PHP consiste em uma maneira de preservar certos dados
-   atráves dos acessos subsequentes. Isto permite a você fazer aplicações mais
-   personalizadas e melhorar a aparência do seu web site.
+   atráves dos acessos subsequentes.
   </para>
   <para>
    Um visitante acessando o seu web site ganha um identificador único,
-   o assim chamado id de sessão. Este é salvo em um cookie do lado do
+   o assim chamado id de sessão. Ele é salvo em um cookie do lado do
    usuário ou propagado via URL.
   </para>
   <para>
-   O suporte a sessão permite a você registrar um número arbritrário
-   de variáveis que serão preservadas entre as requisições. Quando um visitante
-   acessar o seu site, o PHP irá conferir automaticamente (se <link
-   linkend="ini.session.auto-start">session.auto_start</link>
+   O suporte à sessão permite armazenar dados entre as requisições no
+   array super global <varname>$_SESSION</varname>. Quando um visitante acessar
+   seu site, o PHP vai conferir automaticamente (se <link linkend="ini.session.auto-start">session.auto_start</link>
    estiver definido como 1) ou quando você pedir (explicitamente atráves de
-   <function>session_start</function> ou implicitamente através de
-   <function>session_register</function>) quando um id de sessão específico
-   for enviado com a requisição. Se este for o caso, o ambiente
+   <function>session_start</function>) se um id de sessão específico
+   foi enviado com a requisição. Se este for o caso, o ambiente
    anteriormente salvo é recriado.
   </para>
-   <caution>
-    <para>
-     Se você ativar <link linkend="ini.session.auto-start">
-     session.auto_start</link> então você não poderá colocar objetos em
-     suas sessões já que a definição deve ser carregada
-     antes de começar a sessão para poder recriar os
-     objetos da sua sessão.
-    </para>
-   </caution>
+  <caution>
+   <para>
+    Se você ativar <link linkend="ini.session.auto-start">
+    session.auto_start</link>, então a única maneira de colocar objetos
+    em suas sessões é carregando a definição da classe usando
+    <link linkend="ini.auto-prepend-file">auto_prepend_file</link>,
+    onde você pode carregar a definição da classe, caso contrário você terá que
+    usar <function>serialize</function> no objeto,
+    e <function>unserialize</function> nele
+    depois.
+   </para>
+  </caution>
   <para>
-   Todas as variáveis são serializadas depois das solicitações terminarem.
-   Variáveis registradas as quais não estejam definidas são marcadas como
-   sendo não definidas. Nos acessos subsequentes, estas não são
-   definidas pelo módulo da sessão a menos que o usuário defina elas posteriormente.
+   <varname>$_SESSION</varname> (e todas as variávels registradas) são serializadas
+   internamente pelo PHP usando o manipulador de serialização especificado pela
+   configuração INI <link linkend="ini.session.serialize-handler">session.serialize_handler</link>
+   depois que a requisição terminar.  Variáveis registradas que estejam indefinidas são
+   marcadas como não definidas.  Nos acessos subsequentes, elas não são definidas
+   pelo módulo da sessão, a menos que o usuário as definam posteriormente. 
   </para>
   <warning>
    <para>
-    Alguns tipos de dados não podem ser serializados e assim guardados em sessões.
-    Isso inclui variáveis de <type>resource</type>(recursos) ou objetos com
-    referências circulares (ex. objetos que passam uma referência de
-    si mesmo para outro objeto).
+    Porque as variáveis de sessão são serializadas, variáveis <type>resource</type> não podem
+    ser armazenadas em sessão.
+   </para>
+   <para>
+     Manipuladores de serialização (<literal>php</literal>
+     e <literal>php_binary</literal>) herdam as limitações de
+     register_globals. Portanto, índices numéricos ou strings contendo
+     caracteres especiais (<literal>|</literal>
+     e <literal>!</literal>) não podem ser usados. Se usados, resultará em
+     erros na finalização do script. <literal>php_serialize</literal>
+     não possui tais limitações. <literal>php_serialize</literal>
+     está disponível a partir do PHP 5.5.4.
    </para>
   </warning>
   <note>
    <para>
-    A manipulação de sessões foi adicionada no PHP 4.0.0.
+    Por favor, note que ao trabalhar com sessões, um registro na sessão
+    não é criado até que a variável seja registrada usando a função
+    <function>session_register</function> ou pela adição de uma nova
+    chave ao array super global <varname>$_SESSION</varname>. Isto
+    continua valendo mesmo se uma sessão foi iniciada usando a função
+    <function>session_start</function>.
    </para>
   </note>
   <note>
    <para>
-    Por favor note que ao trabalhar com sessões que um registro da sessão não é
-    criado até que a variável seja registrada usando a função
-    <function>session_register</function> ou pela adição de uma
-    nova chave a array superglobal <varname>$_SESSION</varname>. Isto
-    é verdadeiro não importando se uma sessão foi iniciada usando a função
-    <function>session_start</function>.
+    O PHP 5.2.2 introduziu uma funcionalidade não documentada para armazenar os arquivos de sessão
+    em "/tmp" mesmo que <link linkend="ini.open-basedir">open_basedir</link>
+    estivesse habilitado e "/tmp" não fosse adicionado explicitamente na lista de caminhos
+    permitidos. Esta funcionalidade foi removida a partir do PHP 5.3.0.
    </para>
   </note>
  </preface>

--- a/pt_BR/reference/session/configure.xml
+++ b/pt_BR/reference/session/configure.xml
@@ -1,28 +1,26 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 297028 Maintainer: fernandoc Status: ready -->
-<!-- CREDITS: surfmax -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 297028 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
 <section xml:id="session.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
  <para>
-  Suporte a sessões está habilitado no PHP por definição. Se você não
-  gostaria de construir o seu PHP sem esse suporte, você especificaria a opção
-   <option role="configure">--disable-session</option>
-  para configurar. Para utilizar uma alocação de memória dividida (mm) para armazenamento de sessão configure o PHP com <option role="configure">--with-mm[=DIR] </option>.
+  Suporte à sessão está habilitado no PHP por padrão. Se você preferir
+  compilar o PHP sem suporte à sessão, você deve
+  especificar a opção <option role="configure">--disable-session</option>
+  para o script configure. Para usar alocação de memória compartilhada (mm) para armazenamento
+  de sessão especifique a opção <option role="configure">--with-mm[=DIR] </option>.
  </para>
  &windows.builtin;
  <note>
   <para>
-   Por definição, todos os dados relaciondos uma uma sessão em particular
-   serão guardados num arquivo no diretório especificado 
-   pela opção session.save_path INI .
-   Um arquivo para cada sessão (apesar de quaisquer dados estarem associados
-   com essa sessão) será criada. Isto é devido ao fato de que uma sessão é
-   aberta (um aquivo é criado) mas até então nenhum dado é escrito nesse
-   arquivo. Note que este comportamento é um efeito colateral da limitação
-   do traalho com o arquivo de sistema e é possível que um manipulador de
-   sessão customizado(tal como é usado em banco de dados)  
-   não manterá registro de sessões
-   que não guardaram nenhum dado. 
+   Por padrão, todos os dados relacionados com uma sessão em particular serão armazenados em
+   um arquivo no diretório especificado pela configuração INI session.save_path.
+   Um arquivo para cada sessão (independente se alguma informação está associada com
+   esta sessão) será criado. Isto é devido ao fato de que uma sessão
+   é aberta (um arquivo é criado) mas até então nenhum dado é escrito neste arquivo.
+   Note que este comportamento é um efeito colateral das limitações de trabalhar
+   com o sistema de arquivo e é possível que um manipulador de sessão personalizado
+   (como um que utilize banco de dados) não mantenha registros das sessões
+   que não contém dados.
   </para>
  </note> 
 </section>

--- a/pt_BR/reference/session/constants.xml
+++ b/pt_BR/reference/session/constants.xml
@@ -1,19 +1,55 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: felipe Status: ready -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 323726 Maintainer: felipe Status: ready -->
 <appendix xml:id="session.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;
  <variablelist>
-  <varlistentry>
+  <varlistentry xml:id="constant.sid">
    <term>
     <constant>SID</constant> 
     (<type>string</type>)
    </term>
    <listitem>
     <simpara>
-     Constante contendo nome da sessão e id da sessão na forma de
-     <literal>"name=ID"</literal> ou string vazia
-     se o ID da sessão não foi definido em um apropriado cookie de sessão.
+     Constante contendo nome da sessão e id da sessão na
+     forma de <literal>"name=ID"</literal> ou string vazia
+     se o ID da sessão foi definido em um apropriado cookie de sessão. Este é
+     o mesmo id que é retornado por <function>session_id</function>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-session-disabled">
+   <term>
+    <constant>PHP_SESSION_DISABLED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     A partir do PHP 5.4.0. Retorna o valor de <function>session_status</function> se as sessões estiverem desabilitadas.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-session-none">
+   <term>
+    <constant>PHP_SESSION_NONE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     A partir do PHP 5.4.0. Retorna o valor de <function>session_status</function> se as sessões estiverem habilitadas,
+     mas nenhuma sessão existir.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-session-active">
+   <term>
+    <constant>PHP_SESSION_ACTIVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     A partir do PHP 5.4.0. Retorna o valor de <function>session_status</function> se as sessões estiverem habilitadas,
+     e uma sessão existir.
     </simpara>
    </listitem>
   </varlistentry>

--- a/pt_BR/reference/session/examples.xml
+++ b/pt_BR/reference/session/examples.xml
@@ -1,52 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 337307 Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
+
 <appendix xml:id="session.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
  <section xml:id="session.examples.basic">
-  <note>
+  <title>Uso básico</title>
    <para>
-    A partir do PHP 4.1.0, <varname>$_SESSION</varname> está disponível como uma
-    variável global como <varname>$_POST</varname>,
-    <varname>$_GET</varname>, <varname>$_REQUEST</varname> e assim por diante.
-    Diferentemente de <varname>$HTTP_SESSION_VARS</varname>,
-    <varname>$_SESSION</varname> é sempre global. Entretanto, você não
-    precisa usar a palavra <link
-    linkend="language.variables.scope"><command>global</command></link>
-    para <varname>$_SESSION</varname>. por favor note que esta
-    documentação foi modifcada para usar
-    <varname>$_SESSION</varname> em todos os lugares. Você pode substituir
-    <varname>$HTTP_SESSION_VARS</varname> por
-    <varname>$_SESSION</varname>, se você prefirir. Também note
-    que você precisa começar a sua sessão usando <function>session_start</function>
-    antes que <varname>$_SESSION</varname> esteja disponível.
+    Sessões são uma forma simples de armazenar dados para usuários individuais usando um ID de sessão único.
+    Sessões podem ser usadas para persistir informações entre requisições de páginas.  IDs de sessão normalmente são
+    enviados ao navegador através de cookies de sessão e o ID é usado para recuperar dados da sessão existente.
+    A ausência de um ID ou cookie de sessão permite que o PHP saiba que deve criar uma nova sessão e gerar um novo
+    ID de sessão.
    </para>
    <para>
-    As chaves para a array associativa <varname>$_SESSION</varname>
-    estão sujeitas ao mesmas limitações
-    que as os nomes de variáveis regulares do PHP, ex elas não
-    podem começar com um numero e devem começar com uma letra ou sublinhado;.
-    Para maiores detalhes veja a sessão sobre
-    <link linkend="language.variables">variaveis</link> neste manual.
+    Sessões seguem um fluxo simples.  Quando uma sessão é iniciada, o PHP recupera uma
+    sessão existente usando o ID informado (normalmente de um cookie de sessão) ou se nenhum é informado
+    então será criada uma nova sessão.  O PHP preencherá a super global <varname>$_SESSION</varname>
+    com todos os dados de sessão depois que a sessão iniciar.  Quando o PHP finalizar, automaticamente ele
+    pegará o conteúdo da super global <varname>$_SESSION</varname>, então vai serializá-lo e enviá-lo
+    para armazenamento usando o manipulador de gravação da sessão.
    </para>
-  </note>
-
+   <para>
+    Por padrão, o PHP usa o manipulador de gravação interno <parameter>files</parameter> que
+    é configurado por <link linkend="ini.session.save-handler">session.save_handler</link>.
+    Isto salva os dados da sessão no servidor no local configurado pela
+    diretiva de configuração <link linkend="ini.session.save-path">session.save_path</link>.
+   </para>
+   <para>
+    Sessões podem ser iniciadas manualmente usando a função <function>session_start</function>.
+    Se a diretiva <link linkend="ini.session.auto-start">session.auto_start</link> estiver configurada
+    como <parameter>1</parameter>, a sessão será iniciada automaticamente no início da requisição.
+   </para>
+   <para>
+    Sessões normalmente se encerram automaticamente quando o PHP termina de executar um script, mas podem ser
+    encerradas manualmente usando a função <function>session_write_close</function>.
+   </para>
   <para>
-   Se <link
-   linkend="ini.register-globals">register_globals</link>
-   estiver desativado, apenas membros da matriz associativa global
-   <varname>$_SESSION</varname> podem ser registrados como
-   variáveis de sessão. As variavéis de sessão restauradas apenas estarão disponíveis
-   na array <varname>$_SESSION</varname>.
-  </para>
-  <para>
-   O uso de <varname>$_SESSION</varname> (ou
-   <varname>$HTTP_SESSION_VARS</varname> com PHP 4.0.6 ou anterior) é
-   recomendado para melhor segurança e facilidade de leitura do código. Com
-   <varname>$_SESSION</varname>, não há necessidade de usar as funções
-   <function>session_register</function>,
-   <function>session_unregister</function>,
-   <function>session_is_registered</function>. Variáveis de sessão
-   são acessíveis como qualquer outra variável.
    <example>
     <title>
      Registrando uma variável com <varname>$_SESSION</varname>.
@@ -55,7 +44,6 @@
 <![CDATA[
 <?php
 session_start();
-// Use $HTTP_SESSION_VARS with PHP 4.0.6 or less
 if (!isset($_SESSION['count'])) {
   $_SESSION['count'] = 0;
 } else {
@@ -67,15 +55,12 @@ if (!isset($_SESSION['count'])) {
    </example>
    <example>
     <title>
-     Desregistrando uma variável com <varname>$_SESSION</varname> e
-     <link
-     linkend="ini.register-globals">register_globals</link> desabilitado.
+     Desregistrando uma variável com <varname>$_SESSION</varname>.
     </title>
     <programlisting role="php">
 <![CDATA[
 <?php
 session_start();
-// Use $HTTP_SESSION_VARS with PHP 4.0.6 or less
 unset($_SESSION['count']);
 ?>
 ]]>
@@ -86,63 +71,45 @@ unset($_SESSION['count']);
    <caution>
     <para>
      NÃO desregistre toda a <varname>$_SESSION</varname> com
-     <literal>unset($_SESSION)</literal> já que isso irá desativar o
-     registro de variáveis de sessão atráves da
-     superglobal <varname>$_SESSION</varname>.
+     <literal>unset($_SESSION)</literal> já que isso desativará o
+     registro de variáveis de sessões da
+     super global <varname>$_SESSION</varname>.
     </para>
    </caution>
   </para>
   <warning>
    <para>
-    Você não pode usar referências em variáveis de sessão já que não existe uma
-    maneira de restaurar uma referência a outra variável.
+    Referências não podem ser usadas nas variáveis de sessão já que não existe uma maneira
+    de restaurar uma referência para outra variável.
    </para>
   </warning>
-  <para>
-   Se <link
-   linkend="ini.register-globals">register_globals</link>
-   estiver ativada, então cada variável global pode ser registrada como uma
-   variável de sessão. Após o reinicio da sessão, estas variáveis serão restauradas
-   a suas variáveis globais correspondentes. Já que o PHP deve saber quais variáveis
-   globais devem ser registradas como variáveis de sessão, o usuário precisa registrar
-   as variáveis com a função <function>session_register</function>.
-   Você pode evitar isso simplesmente definindo entradas em
-   <varname>$_SESSION</varname>.
-   <caution>
-    <para>
-     Antes do PHP 4.3, se você estiver usando <varname>$_SESSION</varname> e você
-     desabilitou <link linkend="ini.register-globals">register_globals</link>,
-     não use <function>session_register</function>,
-     <function>session_is_registered</function> ou
-     <function>session_unregister</function>.
-      Desabilitar <link
-      linkend="ini.register-globals">register_globals</link>
-      é recomendado por motivo de segurança e performance.
-    </para>
-   </caution>
-  </para>
-  <para>
-   Se <link
-   linkend="ini.register-globals">register_globals</link>
-   estiver ativada, então as variáveis globais e as entradas em
-   <varname>$_SESSION</varname> irão automaticamente referenciar os mesmos valores
-   que estejam registrados na instancia da sessão anterior.
-   Entretanto, se a variável for registrada por <varname>$_SESSION</varname>
-   então a variável global estará disponível a partir da proxima requisição.
-  </para>
-  <para>
-   Existe um defeito no PHP 4.2.3 e anterior. Se você registrar uma
-   nova variável de sessão usando <function>session_register</function>, a
-   entrada no escopo global e a entrada em <varname>$_SESSION</varname>
-   não irão se referir ao mesmo valor até o próximo
-   <function>session_start</function>. Ex: uma modificação na variável
-   global recém registrada não será refletida pela entrada em
-   <varname>$_SESSION</varname>. Isto foi corrigido no PHP 4.3.0.
-  </para>
+  <warning>
+   <para>
+    register_globals sobrescreverá as variáveis no escopo global que compartilham o mesmo nome com as variáveis de sessão. Por favor veja <link linkend="security.globals">Usando a diretiva Register Globals</link> para detalhes.
+   </para>
+  </warning>
+  <note>
+   <para>
+    Sessões baseadas em arquivos (padrão no PHP) adicionam travas no arquivo de sessão assim que
+    a sessão é iniciada via <function>session_start</function> ou simplesmente via
+    <link linkend="ini.session.auto-start">session.auto_start</link>. Assim que
+    adicionada a trava, nenhum outro script pode acessar o mesmo arquivo de sessão até que ela
+    seja finalizada pelo encerramento do primeiro script ou pela chamada de
+    <function>session_write_close</function>.
+   </para>
+   <para>
+    Isto é possivelmente um problema para web sites que utilizam fortemente o AJAX e
+    que tem múltiplas solicitações concorrentes. A maneira mais fácil de lidar com isto é
+    chamar <function>session_write_close</function> assim que as
+    alterações necessárias na sessão forem feitas, de preferência no início do script.
+    Como alternativa, um manipulador de sessão diferente que suporte concorrência
+    poderia ser usado.
+   </para>
+  </note>
  </section>
-  
+
  <section xml:id="session.idpassing">
-  <title>Passando o ID de Sessão</title>
+  <title>Passando o ID de sessão</title>
   <para>
    Existem dois métodos para a propagação do id de sessão:
    <itemizedlist>
@@ -160,37 +127,37 @@ unset($_SESSION['count']);
   </para>
   <para>
    O módulo de sessão suporta ambos os métodos. Cookies são melhores, mas
-   como eles nem sempre estão disponíveis, nós também provemos um caminho alternativo.
-   O segundo metodo embute o id de sessão diretamente nas URLs.
+   como nem sempre eles estão disponíveis, também é oferecido um método
+   alternativo.  O segundo método embute o id de sessão diretamente nas URLs.
   </para>
   <para>
-   O PHP é capaz de transformar os links transparentemente. A menos que você esteja
-   usando o PHP 4.2 ou posterior, você precisa ativar isso manualmente ao compilar o PHP.
-   No Unix, passe <link linkend="ini.session.use-trans-sid">
-   --enable-trans-sid</link> para o configure. Se esta opção de compilação e a
-   opção em tempo execução
+   O PHP é capaz de transformar os links transparentemente. A menos que você esteja usando o
+   PHP 4.2.0 ou posterior, é necessário ativar manualmente ao compilar o PHP.
+   Em ambiente Unix, passe <link linkend="ini.session.use-trans-sid">
+   --enable-trans-sid</link> para o configure. Se esta
+   opção de compilação e a opção em tempo de execução
    <literal>session.use_trans_sid</literal> estiverem ativadas,
    URIs relativas serão modificadas para conter o id de sessão automaticamente.
    <note>
     <para>
-     A diretiva <link linkend="ini.arg-separator.output">arg_separator.output</link>
-     &php.ini; permite a você personalizar o separador de argumentos. Para estar
-     em completa conformidade com XHTML, especifique &amp;amp; aqui.
+     O <link linkend="ini.arg-separator.output">arg_separator.output</link>,
+     diretiva &php.ini;, permite configurar o separador de argumentos. Para completa
+     conformidade com XHTML, especifique &amp;amp; aqui.
     </para>
-   </note> 
+   </note>
   </para>
   <para>
-   Alternativamente, você pode usar a constante <literal>SID</literal> a qual é
-   definida se uma sessão é iniciada. Se o cliente não enviou um cookie de sessão apropriado,
-   ela tem a forma <literal>session_name=session_id</literal>.
-   Se não, ela expande para uma string vazia. Assim, você pode colocá-la
+   Alternativamente, pode ser usada a constante <constant>SID</constant>, a qual é
+   definida se uma sessão é iniciada.  Se o cliente não enviou um cookie de sessão
+   apropriado, a constante terá o formato <literal>session_name=session_id</literal>.
+   Se não, ela será uma string vazia. Dessa forma, ela pode ser colocada
    incondicionalmente em URLs.
   </para>
   <para>
-   O exemplo a seguir mostra como registrar uma variável, e como
-   criar um link corretamente para outra pagina usando SID.
+   O exemplo a seguir demonstra como registrar uma variável e
+   como criar um link corretamente para outra página usando o <constant>SID</constant>.
    <example>
-    <title>Contando o número de visitas de um único usuário</title>
+    <title>Contando o número de acessos de um único usuário</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -198,49 +165,89 @@ unset($_SESSION['count']);
 session_start();
 
 if (empty($_SESSION['count'])) {
- $_SESSION['count'] = 1;
+   $_SESSION['count'] = 1;
 } else {
- $_SESSION['count']++;
+   $_SESSION['count']++;
 }
 ?>
 
 <p>
-Hello visitor, you have seen this page <?php echo $_SESSION['count']; ?> times.
+Olá visitante, você acessou esta página <?php echo $_SESSION['count']; ?> vezes.
 </p>
 
 <p>
-To continue, <a href="nextpage.php?<?php echo htmlspecialchars(SID); ?>">click
-here</a>.
+Para continuar, <a href="nextpage.php?<?php echo htmlspecialchars(SID); ?>">clique
+aqui</a>.
 </p>
 ]]>
     </programlisting>
    </example>
   </para>
   <para>
-   A função <function>htmlspecialchars</function> é usada ao mostrar o SID
-   para previnir ataques relacionados a XSS.
+   A função <function>htmlspecialchars</function> pode ser usada ao mostrar o <constant>SID</constant>
+   com o intuito de prevenir ataques relacionados a XSS.
   </para>
   <para>
-   Mostrar o SID, como mostrado acima, não é necessário se
+   Mostrar o <constant>SID</constant>, como mostrado acima, não é necessário se
    <link linkend="ini.session.use-trans-sid">
-   --enable-trans-sid</link> foi usado para compilar o PHP.
+    --enable-trans-sid</link> foi usado para compilar o PHP.
   </para>
   <note>
    <para>
-    É assumido para URLs não relativas que apontem para sites externos
-    e assim não é adicionado o SID, já que seria um risco de segurança
-    vazar o SID para um servidor diferente.
+    Para URLs não-relativas, assume-se que elas apontam para sites externos e
+    por isso não é adicionado o <constant>SID</constant>, já que seria um risco de segurança
+    vazar o <constant>SID</constant> para um servidor diferente.
    </para>
   </note>
  </section>
- 
+
  <section xml:id="session.customhandler">
-  <title>Manipuladores de sessões personalizados</title>
+  <title>Manipuladores de Sessão Personalizados</title>
   <para>
-   Para implementar as sessões em banco de dados, ou qualquer outro método de
-   armazenamento, você precisara usar <function>session_set_save_handler</function>
-   para criar um conjunto de funções de armazenamento.
+   Para implementar as sessões em banco de dados, ou qualquer outro método de armazenamento, é
+   preciso usar <function>session_set_save_handler</function> para
+   criar um conjunto de funções de armazenamento a nível de usuário. A partir do PHP 5.4.0 podem ser criados manipuladores de sessões
+   usando <classname>SessionHandlerInterface</classname> ou estender os manipuladores internos do PHP herdando
+   de <classname>SessionHandler</classname>.
   </para>
+  <para>
+   Os callbacks especificados em <function>session_set_save_handler</function> são métodos
+   executados pelo PHP durante o ciclo de vida de uma sessão: <parameter>open</parameter>, <parameter>read</parameter>,
+   <parameter>write</parameter> e <parameter>close</parameter> e para as tarefas de manutenção:
+   <parameter>destroy</parameter> para deletar uma sessão e <parameter>gc</parameter> para recolha periódica
+   de lixo.
+  </para>
+  <para>
+   Portanto, o PHP sempre requer manipuladores de gravação de sessão. O padrão normalmente é
+   o manipulador de gravação interno de 'arquivos'. Um manipulador personalizado pode ser configurado usando
+   <function>session_set_save_handler</function>. Manipuladores internos alternativos também são
+   disponibilizados por extensões do PHP, como <parameter>sqlite</parameter>,
+   <parameter>memcache</parameter> e <parameter>memcached</parameter> e podem ser definidos com
+   <link linkend="ini.session.save-handler">session.save_handler</link>.
+  </para>
+  <para>
+    Quando a sessão inicia, o PHP internamente executa o manipulador <parameter>open</parameter> seguido pelo
+    callback <parameter>read</parameter> que deve retornar uma string codificada exatamente como foi originalmente
+    passado para armazenamento. Após o <parameter>read</parameter> retornar a string codificada, o PHP vai
+    decodificá-la e colocar o array resultante na super global <varname>$_SESSION</varname>.
+  </para>
+  <para>
+    Quando o PHP é encerrado (ou quando <function>session_write_close</function> for chamada),
+    o PHP internamente vai codificar a super global <varname>$_SESSION</varname> e passá-la
+    junto com o ID de sessão para o callback <parameter>write</parameter>.
+    Depois que o callback <parameter>write</parameter> finalizar, o PHP internamente invocará o
+    callback <parameter>close</parameter>.
+  </para>
+  <para>
+   Quando uma sessão é destruída, o PHP chamará o manipulador <parameter>destroy</parameter> com
+   o ID de sessão.
+  </para>
+  <para>
+   O PHP executará o callback <parameter>gc</parameter> de tempo em tempo para
+   apagar quaisquer informações na sessão de acordo com o tempo de vida máximo (lifetime) definido para a sessão.
+   Esta rotina deve apagar todas as informações do armazenamento persistente em que
+   a diferença de tempo do último acesso até o momento atual seja maior que <parameter>$lifetime</parameter>.
+ </para>
  </section>
 </appendix>
 

--- a/pt_BR/reference/session/ini.xml
+++ b/pt_BR/reference/session/ini.xml
@@ -37,7 +37,7 @@
     <row>
      <entry><link linkend="ini.session.auto-start">session.auto_start</link></entry>
      <entry>"0"</entry>
-     <entry>PHP_INI_ALL</entry>
+     <entry>PHP_INI_PERDIR</entry>
      <entry></entry>
     </row>
     <row>
@@ -226,8 +226,8 @@
  &ini.php.constants;
  </para>
  <para>
-  O sistema de gerenciamento de sessões suporta várias opções de configuração
-  que você pode colocar em seu arquivo &php.ini;. A seguir
+  O sistema de gerenciamento de sessões suporta várias opções de configurações
+  que podem ser colocados no arquivo &php.ini;. A seguir
   um breve resumo.
  <variablelist>
 
@@ -239,7 +239,7 @@
    <listitem>
     <simpara>
      <literal>session.save_handler</literal> define o nome do
-     manipulador que será utilizado para armazenar a recuperar dados
+     manipulador que será utilizado para armazenar e recuperar dados
      associados à sessão. Padrão para 
      <literal>files</literal>. Note que extensões podem registrar seus
      próprios <literal>save_handler</literal>s; manipuladores registrados podem
@@ -257,31 +257,31 @@
    </term>
    <listitem>
     <simpara>
-     <literal>session.save_path</literal> define o argumento que é passado
-     para o manipulador de gravação. Se você escolher o manipulador de
-     padrão (files), este é o caminho onde os arquivos serão criados. Veja também
+     <literal>session.save_path</literal> define o argumento que
+     é passado para o manipulador de gravação. Se você escolher o manipulador padrão (de
+     arquivos), este é o caminho onde os arquivos serão criados. Veja também
      <function>session_save_path</function>. 
     </simpara>
     <para>
-     Há um argumento N opcional para esta dietiva que determina o número
-     de níveis de diretório que seus arquivos de sessão serão espalhados.
-     Por exemplo, definindo para <literal>'5;/tmp'</literal>
-     pode levar a criação de um arquivo de sessão e localização como
+     Há um argumento opcional <literal>N</literal> para esta diretiva que determina
+     o número de níveis de diretório que seus arquivos de sessão serão
+     espalhados. Por exemplo, definindo para <literal>'5;/tmp'</literal>
+     pode levar a criação de um arquivo de sessão e diretórios como
      <literal>/tmp/4/b/1/e/3/sess_4b1e384ad74619bd212e236e52a5a174If
-     </literal>. Para fazer uso do N você deve criar todos estes diretórios
-     antes do uso. Um pequeno script shell existe em
+     </literal>. Para fazer uso do <literal>N</literal> você deve criar todos estes
+     diretórios antes do uso. Um pequeno script shell existe em
      <filename>ext/session</filename> para fazer isto, chamado
      <filename>mod_files.sh</filename>, com uma versão para o Windows chamada
-     <filename>mod_files.bat</filename>. Também note se N é usada e maior
-     do que 0 então a limpeza de sessões não 
+     <filename>mod_files.bat</filename>. Também note que se <literal>N</literal> é
+     usado e maior do que 0 então a limpeza de sessões não 
      será executada, veja uma cópia do &php.ini; para mais
-     informações. Se você usar N, certifique-se de cercar
+     informações. Também, se você usar <literal>N</literal>, certifique-se de cercar
      <literal>session.save_path</literal> com  
      "aspas" porque o separador (<literal>;</literal>) é
-     também usado para comentátios no &php.ini;.
+     usado também para comentátios no &php.ini;.
     </para>
     <para>
-     O armazenamento em arquivos criam arquivos com permissões 600 por padrão.
+     O módulo de armazenamento em arquivo cria arquivos com permissões 600 por padrão.
      Esse padrão pode ser alterado com o argumento opcional <literal>MODE</literal>:
      <literal>N;MODE;/path</literal> onde <literal>MODE</literal> é o valor octal
      representando as permissões.
@@ -289,30 +289,30 @@
     </para>
     <warning>
      <para>
-      Se você deixar isto definido num diretório de leitura público, 
-      tal como <filename>/tmp</filename> (o padrão), outros usuários no
-      servidor poderão raptar sessõoes pegando a lista de arquivos nesse
-      diretório.
+      Se você deixar isto definido num diretório de leitura público, como
+      <filename>/tmp</filename> (o padrão), outros usuários no
+      servidor poderão raptar sessõoes pegando a lista de
+      arquivos nesse diretório.
      </para>
     </warning>
     <caution>
      <para>
-      Quando utilizando a opção de diretório <literal>N</literal> como
-      descrito acima, note que utilizando um valor maior que 1 ou 2 é
+      Ao utilizar o argumento opcional de nível de diretório <literal>N</literal>,
+      como descrito acima, note que utilizar um valor maior que 1 ou 2 é
       inapropriado na maioria dos sites por conta da geração de um grande número de diretórios
       exigidos: por exemplo, um valor de 3 implica que existirão <literal>64^3</literal>
-      diretórios em disco, o que resolta numa quantidade enorme de espaço e
+      diretórios em disco, o que pode resultar numa quantidade enorme de espaço e
       inodes desperdiçados.
      </para>
      <para>
       Somente use <literal>N</literal> maiores que 2 se você estiver absolutamente
-      certo que o seu site é grande o suficiente para requerir isso.
+      certo que o seu site é grande o suficiente para exigí-lo.
      </para>
     </caution>
     <note>
      <simpara>
-      Antes do PHP 4.3.6 os usuários de Windows tem que mudar esta variável para
-      fazer funções de sessão no PHP. Certifique-se de especifica um caminho válido, ex.:
+      Antes do PHP 4.3.6 os usuários de Windows tinham que mudar esta variável para
+      usar as funções de sessão do PHP. Um caminho válido deve ser especificado, ex.:
       <filename>c:/temp</filename>.
      </simpara>
     </note>
@@ -326,9 +326,9 @@
    </term>
    <listitem>
     <simpara>
-     <literal>session.name</literal> especifíca o nome da sessão
-     que é usada como um nome de cookie. Deve conter apenas
-     caracteres alfanuméricos. Padrão inicial <literal>PHPSESSID</literal>.
+     <literal>session.name</literal> especifica o nome da
+     sessão que é usada como o nome do cookie. Deve conter apenas
+     caracteres alfanuméricos. O padrão é <literal>PHPSESSID</literal>.
      Veja também <function>session_name</function>.
     </simpara>
    </listitem>
@@ -341,9 +341,9 @@
    </term>
    <listitem>
     <simpara>
-     <literal>session.auto_start</literal> especifíca se o módulo da sessão
-     de executar automaticamente início da execução.
-     Padrão <literal>0</literal> (desabilitado).
+     <literal>session.auto_start</literal> especifica se o
+     módulo da sessão deve iniciar uma sessão automaticamente no início
+     da requisição. Padrão <literal>0</literal> (desabilitado).
     </simpara>
    </listitem>
   </varlistentry>
@@ -356,15 +356,15 @@
    <listitem>
     <simpara>
      <literal>session.serialize_handler</literal> define o nome do
-     formatador utilizado para serializar/desserializar dados. São suportados o formato
+     manipulador utilizado para serializar/desserializar dados. São suportados o formato
      serial do PHP (<literal>php_serialize</literal>), o formato interno
      do PHP (<literal>php</literal> e
      <literal>php_binary</literal>) e WDDX
-     (<literal>wddx</literal>). O WDDX somente está disponível se o PHP estiver
+     (<literal>wddx</literal>). O WDDX somente está disponível se o PHP foi
      compilado com <link linkend="ref.wddx">suporte
      WDDX</link>. <literal>php_serialize</literal> está disponível
-     desde o PHP 5.5.4. <literal>php_serialize</literal> utiliza uma função interna
-     para serializar/desserializar os dados e não tem
+     desde o PHP 5.5.4. <literal>php_serialize</literal> utiliza
+     as funções serialize/unserialize internamente e não tem
      as limitações que <literal>php</literal>
      e <literal>php_binary</literal> tem. Serializadores antigos
      não conseguem gravar índices numéricos ou índices string que contenham caracteres
@@ -403,8 +403,8 @@
      <literal>session.gc_probability</literal> define a probabilidade
      que o processo do gc (coletor de lixo) seja iniciado na inicialização de
      cada sessão.
-     A propabilidade é cauculada usando gc_probability/gc_divisor,
-     ex. 1/100 indica que existe 1% de chance que o processo GC comece
+     A probabilidade é cauculada usando gc_probability/gc_divisor,
+     ex. 1/100 indica que existe 1% de chance que o processo GC inicie
      em cada requisição.
      O padrão para <literal>session.gc_divisor</literal> é <literal>100</literal>.
     </simpara>
@@ -418,12 +418,12 @@
    </term>
    <listitem>
     <simpara>
-     <literal>session.gc_maxlifetime</literal> especifíca o número de
-     segundos após os dados terem sido considerados como lixo ('garbage')
-     e eventualmente limpados. Isso pode ocorrer no início da sessão
+     <literal>session.gc_maxlifetime</literal> especifica o número
+     de segundos, que, depois de decorridos, os dados serão considerados como lixo ('garbage') e
+     eventualmente apagados. Isso pode ocorrer no início da sessão
      (dependendo de <link
      linkend="ini.session.gc-probability">session.gc_probability</link> e
-     <link linkend="ini.session.gc-divisor">session.gc_divisor</link>).  
+     <link linkend="ini.session.gc-divisor">session.gc_divisor</link>).
     </simpara>
     <note>
      <para>
@@ -445,9 +445,9 @@
    <listitem>
     <simpara>
      <literal>session.referer_check</literal> contém a 
-     substring que você quer checar contra cada HTTP Referer. Se 
-     o Referer for enviado pelo cliente e a sustring não foi
-     encontrada, a id de sessão será marcada como inválida.
+     substring que você quer checar contra cada HTTP Referer. Se  o
+     Referer for enviado pelo cliente e a sustring não foi
+     encontrada, a id de sessão embutida será marcada como inválida.
      O padrão é uma string vazia.
     </simpara>
    </listitem>
@@ -462,20 +462,20 @@
     <simpara>
      <literal>session.entropy_file</literal> informa o caminho para um
      recurso externo (arquivo) que será usado como uma fonte
-     de entropia no processo de criação da id da sessão. Exemplos são 
+     de entropia no processo de criação da id de sessão. Exemplos são 
      <literal>/dev/random</literal> ou <literal>/dev/urandom</literal>
-     que são disponíveis em muitos sistemas UNIX.
+     que estão disponíveis em muitos sistemas UNIX.
     </simpara>
     <simpara>
-     Esse recurso foi disponibilizado no Windows a partir do PHP 5.3.3.
-     Configurando <literal>session.entropy_length</literal> para um valor diferente de zero
+     Esse recurso é suportado no Windows a partir do PHP 5.3.3. Configurando
+     <literal>session.entropy_length</literal> para um valor diferente de zero
      fará o PHP utilizar o Windows Random API como fonte de entropia.
     </simpara>    
     <note>
      <simpara>
       A partir do PHP 5.4.0 <literal>session.entropy_file</literal> tem como padrão
       <literal>/dev/urandom</literal> ou <literal>/dev/arandom</literal>,
-      o qual estiver disponível. No PHP 5.3.0 essa diretiva está em branco (padrão).
+      se disponível. No PHP 5.3.0 essa diretiva está em branco por padrão.
      </simpara>
     </note>
    </listitem>
@@ -488,7 +488,7 @@
    </term>
    <listitem>
     <simpara>
-     <literal>session.entropy_length</literal> especifíca o número
+     <literal>session.entropy_length</literal> especifica o número
      de bytes que serão lidos do arquivo especificado
      acima. Padrão em <literal>0</literal> (desabilitado).
     </simpara>
@@ -503,11 +503,11 @@
    <listitem>
     <simpara>
      <literal>session.use_strict_mode</literal> especifica se o
-     módulo utilizará o modo id de sessão estrito. Se esse modo estiver ativo
-     o módulo não aceitará um session id não inicializado. Se um session id
-     não inicializado for encaminhado, um novo session id é devolvido.
-     Aplicações são protegidas de fixação de sessões via adoção
-     com esse modo estrito.
+     módulo utilizará o modo id de sessão rigoroso (strict). Se esse modo estiver ativo,
+     o módulo não aceitará um id de sessão não inicializado. Se um id de sessão
+     não inicializado for enviado pelo browser, um novo id de sessão é devolvido para o browser.
+     Aplicações são protegidas da fixação de sessão adotando o
+     modo de sessão rigoroso (strict).
      Padrão é <literal>0</literal> (desativado).
     </simpara>
    </listitem>
@@ -520,8 +520,8 @@
    </term>
    <listitem>
     <simpara>
-     <literal>session.use_cookies</literal> especifica se módulo
-     utilizará cookies para guardar a id da sessão no lado do
+     <literal>session.use_cookies</literal> especifica se o
+     módulo utilizará cookies para guardar a id da sessão no lado do
      cliente. O padrão é <literal>1</literal> (habilitado).
     </simpara>
    </listitem>
@@ -534,12 +534,12 @@
    </term>
    <listitem>
     <simpara>
-     <literal>session.use_only_cookies</literal> especifica que o módulo
-     usará <emphasis role="strong">somente</emphasis> cookies
-     para guardar a id no lado do cliente.
-     Habilitando esta configuração previne ataques envolvendo
-     passagem de ids de sessão nas URLs. Esta configuração foi adicionada no PHP 4.3.0.
-     Padrão <literal>1</literal> (ativado) desde o PHP 5.3.0.
+     <literal>session.use_only_cookies</literal> especifica se
+     o módulo usará <emphasis role="strong">somente</emphasis>
+     cookies para guardar a id no lado do cliente.
+     Habilitar esta configuração previne ataques envolvendo passagem de
+     ids de sessão nas URLs. Esta configuração foi adicionada no PHP 4.3.0.
+     Padrão <literal>1</literal> (ativado) a partir do PHP 5.3.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -552,8 +552,8 @@
    </term>
    <listitem>
     <simpara>
-     <literal>session.cookie_lifetime</literal> especifica o tempo de
-     vida do cookie em segundos que é enviado para o browser. O valor 0
+     <literal>session.cookie_lifetime</literal> especifica o tempo de vida do
+     cookie em segundos que é enviado para o browser. O valor 0
      significa "até o browser ser fechado". O padrão é 
      <literal>0</literal>. Veja também
      <function>session_get_cookie_params</function> e
@@ -575,8 +575,8 @@
    </term>
    <listitem>
     <simpara>
-     <literal>session.cookie_path</literal> especifica o caminho para
-     definir em session_cookie. O padrão é <literal>/</literal>. Veja também
+     <literal>session.cookie_path</literal> especifica o caminho para definir
+     em session_cookie. O padrão é <literal>/</literal>. Veja também
      <function>session_get_cookie_params</function> e
      <function>session_set_cookie_params</function>.
     </simpara>
@@ -591,8 +591,8 @@
    <listitem>
     <simpara>
      <literal>session.cookie_domain</literal> especifica o domínio para
-     definir no cookie de sessão. O padrão é nenhum significando o nome do servidor
-     que gerou o cookie de arcordo com a especificação dos cookies.
+     definir no cookie de sessão. O padrão é nenhum significando o nome do
+     servidor que gerou o cookie de arcordo com a especificação dos cookies.
      Veja também <function>session_get_cookie_params</function> e
      <function>session_set_cookie_params</function>.
     </simpara>
@@ -606,10 +606,10 @@
    </term>
    <listitem>
     <simpara>
-     <literal>session.cookie_secure</literal> especifíca se
-     o cookie seria apenas enviado sob conexões seguras. O padrão é 
+     <literal>session.cookie_secure</literal> especifica se os
+     cookies devem ser enviados apenas em conexões seguras. O padrão é 
      <literal>off</literal>.
-     Esta definição foi adicionada no PHP 4.0.4. Veja também
+     Esta configuração foi adicionada no PHP 4.0.4. Veja também
      <function>session_get_cookie_params</function> e
      <function>session_set_cookie_params</function>.
     </simpara>
@@ -625,8 +625,8 @@
     <simpara>
      Marca o cookie para ser acessível apenas atráves do protocolo HTTP. Isto significa
      que o cookie não será acessível por linguagens de script, como o
-     JavaScript. Esta definição pode efetivamente reduzir o roubo de identidade
-     atráves de ataques XSS (mesmo não sendo suportado por todos os browsers).
+     JavaScript. Esta configuração pode efetivamente reduzir o roubo de identidade
+     atráves de ataques XSS (apesar de não ser suportado por todos os browsers).
     </simpara>
    </listitem>
   </varlistentry>
@@ -638,8 +638,8 @@
    </term>
    <listitem>
     <simpara>
-     <literal>session.cache_limiter</literal> especifíca o método de
-     controle do cache para usar em páginas de sessão.
+     <literal>session.cache_limiter</literal> especifica o método de
+     controle de cache para usar em páginas de sessão.
      Pode ser um dos seguintes valores:
      <literal>nocache</literal>, <literal>private</literal>, 
      <literal>private_no_expire</literal> ou <literal>public</literal>.
@@ -658,8 +658,8 @@
    </term>
    <listitem>
     <simpara>
-     <literal>session.cache_expire</literal> especifíca o time-to-live (tempo de vida)
-     para páginas de sessão, em minutos, não tendo efeito na limitação de
+     <literal>session.cache_expire</literal> especifica o time-to-live (tempo de vida)
+     para páginas de sessão em cache, em minutos, não tendo efeito na limitação de
      nocache. O padrão é <literal>180</literal>. Veja também
      <function>session_cache_expire</function>.
     </simpara>
@@ -680,11 +680,11 @@
     <note>
      <simpara>
       Gerenciamento de sessões baseadas em URLs tem riscos de segurança adicionais
-      comparados ao gerenciamento baseado em cookies. Usuários podem enviar uma URL
-      que contenha uma ID de sessão ativa para seus amigos por
-      e-mail ou usuários pode salvar uma URL que contenha uma ID de sessão em
-      seus bookmarks e acessar seu site sempre com a mesma ID de sessão,
-      por exemplo.
+      comparados ao gerenciamento baseado em cookies. Usuários podem enviar
+      uma URL que contenha uma ID de sessão ativa para seus amigos por
+      e-mail ou usuários podem salvar uma URL que contenha uma ID de sessão em
+      seus bookmarks e acessar seu site sempre com a mesma ID de
+      sessão, por exemplo.
      </simpara>
     </note>
    </listitem>
@@ -697,13 +697,13 @@
    </term>
    <listitem>
     <simpara>
-     Versões do PHP 4.2.3 ou inferior tem um recurso/bug não documentado que
+     Versões do PHP 4.2.3 ou inferior tem um funcionamento/bug não documentado que
      permite inicializar uma variável de sessão no escopo global,
-     embora <link linkend="ini.register-globals">register_globals</link>
-     esteja desabilitado. PHP 4.3.0 e mais novos avisarão você, se este atributo
-     está sendo usado, e se <link linkend="ini.session.bug-compat-warn">
-     session.bug_compat_warn</link> está também habilitado. Este funcionamento/bug
-     pode ser desativado se desativando esta diretiva.
+     mesmo que <link linkend="ini.register-globals">register_globals</link>
+     esteja desabilitado. PHP 4.3.0 e mais novos avisarão se este recurso for
+     usado e se <link linkend="ini.session.bug-compat-warn">
+     session.bug_compat_warn</link> também estiver habilitado. Este funcionamento/bug
+     pode ser desabilitado ao desativar esta diretiva.
     </simpara>
    </listitem>
   </varlistentry>
@@ -715,11 +715,11 @@
    </term>
    <listitem>
     <simpara>
-     Versões do PHP 4.2.0 e inferiores tem um recurso/bug não documentado que
-     que permite inicializar uma variável de sessão no escopo global,
-     embora <link linkend="ini.register-globals">register_globals</link>
-     esteja desabilitado.  HP 4.3.0 e posteriores avisarão a você, se este atributo
-     estiver sendo utilizado com a habilitação de
+     Versões do PHP 4.2.3 e inferiores tem um funcionamento/bug não documentado que
+     permite inicializar uma variável de sessão no escopo global,
+     mesmo que <link linkend="ini.register-globals">register_globals</link>
+     esteja desabilitado.  PHP 4.3.0 e mais novos avisarão se este recurso for
+     usado ao habilitar ambos
      <link linkend="ini.session.bug-compat-42">session.bug_compat_42</link>
      e <link linkend="ini.session.bug-compat-warn">
      session.bug_compat_warn</link>.
@@ -734,7 +734,7 @@
    </term>
    <listitem>
     <simpara>
-     <literal>session.hash_function</literal> permite a você especificar o algoritimo de
+     <literal>session.hash_function</literal> permite especificar o algoritimo de
      hash usado para gerar os IDs de sessão. '0' indica MD5 (128 bits) e
      '1' indica SHA-1 (160 bits).
     </simpara>
@@ -742,8 +742,8 @@
      Desde o PHP 5.3.0 também é possível especificar qualquer um dos algoritmos
      disponibilizados pela <link linkend="ref.hash">extensão hash</link> (se
      habilitada), como <literal>sha512</literal> ou
-     <literal>whirlpool</literal>. A lista completa de algoritmos suportados
-     pode ser obtida na função <function>hash_algos</function>.
+     <literal>whirlpool</literal>. A lista completa de algoritmos suportados pode
+     ser obtida com a função <function>hash_algos</function>.
     </para>
     <note>
      <para>
@@ -761,9 +761,9 @@
    <listitem>
     <simpara>
      <literal>session.hash_bits_per_character</literal> permite a você definir
-     quantos bits são guardaddos em cada caractere ao converter os dados binários
-     de hash para algo que possa ser legível. Os valores possíveis são '4' (0-9, a-f),
-     '5' (0-9, a-v), e '6' (0-9, a-z, A-Z, "-", ",").
+     quantos bits são guardados em cada caractere ao converter os dados binários
+     de hash para algo legível. Os valores possíveis são '4' (0-9, a-f),
+     '5' (0-9, a-v) e '6' (0-9, a-z, A-Z, "-", ",").
     </simpara>
     <note>
      <para>
@@ -780,8 +780,8 @@
    </term>
    <listitem>
     <simpara>
-     <literal>url_rewriter.tags</literal> epecifíca quais tags HTML
-     são reescritas para incluir a id de sessão se o suporte a sid transparente
+     <literal>url_rewriter.tags</literal> especifica quais tags HTML
+     serão reescritas para incluir a id de sessão se o suporte a sid transparente
      estiver habilitado. O padrão é
      <literal>a=href,area=href,frame=src,input=src,form=fakeentry,fieldset=</literal>
     </simpara>
@@ -802,7 +802,7 @@
    <listitem>
     <simpara>
      Permite o rastreamento do progresso de upload, populando a variável <varname>$_SESSION</varname>.
-     Defaults to 1, enabled.
+     O padrão é 1, habilitado.
     </simpara>
    </listitem>
   </varlistentry>
@@ -814,8 +814,8 @@
    </term>
    <listitem>
     <simpara>
-     Limpa a informação de progresso assim que todos os dados POST foram lidos
-     (o upload completado). Padrão 1, habilitador.
+     Limpa a informação de progresso assim que todos os dados POST forem lidos
+     (upload completado). Padrão 1, habilitado.
     </simpara>
     <note>
      <simpara>
@@ -832,7 +832,7 @@
    </term>
    <listitem>
     <simpara>
-     Um prefixo utilizado como chave na variável <varname>$_SESSION</varname>.
+     Um prefixo utilizado na chave da variável <varname>$_SESSION</varname>.
      Essa chave será concatenada com o valor de 
      <literal>$_POST[ini_get("session.upload_progress.name")]</literal> para
      prover um índice único.
@@ -856,7 +856,7 @@
     </simpara>
     <simpara>
      Se <literal>$_POST[ini_get("session.upload_progress.name")]</literal>
-     não for passado ou indisponível, o progresso de upload não será registrado.
+     não for passado ou estiver indisponível, o progresso de upload não será registrado.
     </simpara>
     <simpara>
      Padrão "PHP_SESSION_UPLOAD_PROGRESS".
@@ -871,8 +871,8 @@
    </term>
    <listitem>
     <simpara>
-     Define o quão frequentemente a informação de progresso de upload será atualizada.
-     Isso pode ser definido em bytes ("atualize a informação a cada 100 bytes"), ou em percentagens ("atualize a informação de progresso a cada 1% do total do arquivo").
+     Define a frequência com que a informação de progresso de upload será atualizada.
+     Isso pode ser definido em bytes ("atualize a informação a cada 100 bytes") ou em percentagens ("atualize a informação de progresso a cada 1% do total do arquivo").
     </simpara>
     <simpara>
      Padrão "1%".
@@ -900,8 +900,8 @@
    </term>
    <listitem>
     <simpara>
-     <literal>session.lazy_write</literal> quando configurado para 1 significa que os
-     dados de sessão somente serão reescrito caso eles mudem. Padrão em 1, ativado.
+     <literal>session.lazy_write</literal>, quando configurado para 1, significa que os
+     dados de sessão somente serão reescrito caso eles mudem. O padrão é 1, habilitado.
     </simpara>
    </listitem>
   </varlistentry>
@@ -918,10 +918,10 @@
  </para>
 
  <para>
-  O progresso de upload será registrado apenas se 
-  session.upload_progress.enabled estiver habilitado e a variável
-  $_POST[ini_get("session.upload_progress.name")] existente.
-  Veja <link linkend="session.upload-progress">Progresso de Upload em sessões</link> para mais detalhes da funcionalidade.
+  O progresso de upload não será registrado, a não ser que
+  session.upload_progress.enabled esteja habilitado e a variável
+  $_POST[ini_get("session.upload_progress.name")] esteja definida.
+  Veja <link linkend="session.upload-progress">Progresso de Upload em sessões</link> para mais detalhes dessa funcionalidade.
  </para>
 
 </section>

--- a/pt_BR/reference/session/reference.xml
+++ b/pt_BR/reference/session/reference.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 297028 Maintainer: felipe Status: ready -->
 
 <reference xml:id="ref.session" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/pt_BR/reference/session/security.xml
+++ b/pt_BR/reference/session/security.xml
@@ -1,34 +1,276 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 297028 Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 334226 Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
+
 <chapter xml:id="session.security" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Sessões e segurança</title>
  <para>
-  External links: <link xlink:href="&url.session-fixation;">Session fixation</link>
+  Links externos: <link xlink:href="&url.session-fixation;">Session fixation</link>
  </para>
  <para>
-  O módulo das sessões não pode garantir que a informação que você guarda
-  em uma sessão será visto somente pelo usuário que criou a sessão. Você precisa
-  tomar medidas adicionais de segurança para proteger ativamente a integridade
+  Gerenciamento de sessões HTTP é o núcleo de segurança na web. Toda provenção
+  deve ser adotada para garantir a segurança. Desenvolvedores devem
+  habilitar/utilizar as configurações apropriadamente.
+ </para>
+
+ <itemizedlist>
+  <listitem>
+   <simpara>
+    <link linkend="ini.session.cookie-lifetime">session.cookie_lifetime</link>=0.
+    0 tem um sentido especial. Ele diz ao browser para não guardar os cookies no
+    armazenamento permanente. Portanto, quando o browser é encerrado, o cookie
+    com ID de sessão é deletado imediatamente. Se o desenvolvedor definir valor diferente de 0, pode
+    permitir que outros usuários utilizem o ID da sessão. A maioria das aplicações devem
+    utilizar "0" para esta configuração. Se o recurso de login automático é necessário, implemente
+    seu próprio recurso de login automático de forma segura. Não utilize o ID da sessão para isto.
+   </simpara>
+  </listitem>
+
+  <listitem>
+   <simpara>
+    <link linkend="ini.session.use-cookies">session.use_cookies</link>=On and
+    <link linkend="ini.session.use-only-cookies">session.use_only_cookies</link>=On.
+    Apesar de cookies HTTP terem alguns problemas, cookies é a forma preferida para
+    gerenciar o ID de sessão. Utilize apenas cookies para gerenciamento do ID de sessão quando
+    possível. A maioria das aplicações devem utilizar cookies para o
+    ID de sessão.
+   </simpara>
+  </listitem>
+
+  <listitem>
+   <simpara>
+    <link linkend="ini.session.use-strict-mode">session.use_strict_mode</link>=On.
+    Isto previne o módulo de sessão de utilizar ID de sessão não inicializado. Em
+    outras palavras, o módulo de sessão aceita apenas ID de sessão válido gerado
+    pelo módulo de sessão. ID de sessão fornecidos pelo usuário são
+    rejeitados. Injeção de ID de sessão pode ser feito injetando cookies via
+    JavaScript permanentemente ou temporariamente. Quando sessão transparente está
+    habilitada, o ID de sessão pode ser injetado via query string ou parâmetro de
+    formulário. Não há razão para aceitar ID de sessão fornecida pelo usuário,
+    a maioria das aplicações não devem aceitar ID de sessão não inicializados
+    fornecidos pelo usuário.
+   </simpara>
+  </listitem>
+
+  <listitem>
+   <simpara>
+    <link linkend="ini.session.cookie-httponly">session.cookie_httponly</link>=On.
+    Impede que o JavaScript tenha acesso aos cookies de sessão. Esta configuração
+    previne o roubo de cookies por injeção de JavaScript. É possível
+    usar ID de sessão como proteção CSRF, mas não é
+    recomendado. Por exemplo, o código HTML pode ser salvo e enviado para
+    outros usuários. O desenvolvedor não deve adicionar o ID de sessão nas páginas para
+    manter a segurança. Quase todas as aplicações devem utilizar o atributo httponly para
+    cookie de ID de sessão.
+   </simpara>
+  </listitem>
+
+  <listitem>
+   <simpara>
+    <link linkend="ini.session.cookie-secure">session.cookie_secure</link>=On.
+    Permite acesso ao cookie de ID de sessão apenas quando o protocolo é HTTPS. Se
+    seu web site é todo em HTTPS, você deve habilitar esta
+    configuração. O uso de HSTS deve ser considerado para sites completamentes em HTTPS.
+   </simpara>
+  </listitem>
+
+  <listitem>
+   <simpara>
+    <link linkend="ini.session.gc-maxlifetime">session.gc_maxlifetime</link>=[choose smallest possible].
+    GC trabalha com probabilidade. Esta configuração não garante que sessões
+    antigas serão apagadas. Alguns manipuladores de gravação de sessão não utilizam
+    esta configuração. Veja a documentação para manipuladores de gravação de sessão para
+    detalhes. Apesar do desenvolver não poder depender desta configuração, configurá-la
+    para o menor valor possível é recomendado. Ajuste <link
+    linkend="ini.session.gc-probability">session.gc_probability</link>
+    e <link
+    linkend="ini.session.gc-divisor">session.gc_divisor</link> para que
+    sessões obsoletas sejam deletadas na frequência apropriada. Se o recurso de login automático
+    é necessário, implemente seu próprio recurso de login automático de forma segura.
+    Não utilize ID de sessão com longa vida para isto.
+   </simpara>
+  </listitem>
+
+  <listitem>
+   <simpara>
+    <link linkend="ini.session.use-trans-sid">session.use_trans_sid</link>=Off.
+    O uso do gerenciamento transparente de ID de sessão não é proibido. Ele
+    deve ser usado quando necessário. Contudo, desabilitar o gerenciamento
+    transparente melhora a segurança geral do ID de sessão ao
+    remover a possibilidade de injeção e vazamento do ID de sessão.
+   </simpara>
+  </listitem>
+
+  <listitem>
+   <simpara>
+    <link linkend="ini.session.referer-check">session.referer_check</link>=[your originating URL]
+    Quando <link
+    linkend="ini.session.use-trans-sid">session.use_trans_sid</link>
+    está habilitado, o uso desta configuração é recomendada se for
+    possível. Ela reduz o risco de injeção de ID de sessão. Se seu site é
+    http://example.com/, então defina-o como http://example.com/. Note que quando
+    HTTPS é usado, o browser não enviará o cabeçalho com o referrer. O browser também pode
+    não enviar o cabeçalho com o referrer por configuração. Portanto, esta configuração
+    não é uma medida de segurança confiável.
+   </simpara>
+  </listitem>
+
+  <listitem>
+   <simpara>
+    <link linkend="ini.session.cache-limiter">session.cache_limiter</link>=nocache.
+    Certifique-se de que conteúdo HTTP não sejam salvos em cache para sessão
+    autenticada. Permita cache apenas quando o conteúdo não é
+    privado. Caso contrário, os conteúdos podem ser expostos. "privado" pode ser usado
+    se o conteúdo HTTP não inclui dados sensíveis. Note
+    que "privado" pode deixar informações privadas salvas em cache por clientes
+    compartilhados. "public" pode ser usado apenas quando o conteúdo HTTP não
+    contém informação privada.
+   </simpara>
+  </listitem>
+
+  <listitem>
+   <simpara>
+    <link linkend="ini.session.hash-function">session.hash_function</link>="sha256".
+    Funções de hash mais fortes irão gerar ID de sessão mais
+    fortes. Apesar de colisão no hash ser pouco provável até mesmo com hash MD5, desenvolvedores
+    devem usar funções de hash SHA-2 ou posterior para a tarefa. Desenvolvedores podem
+    utilizar hashes mais fortes, como sha384 e sha512.
+   </simpara>
+  </listitem>
+ </itemizedlist>
+ 
+ <para>
+  O módulo de sessão não pode garantir que a informação que você guarda
+  em uma sessão será visto somente pelo usuário que criou a sessão. Medidas adicionais
+  de segurança devem ser tomadas para proteger ativamente a integridade
   da sessão, dependendo do valor dos dados.
  </para>
+
  <para>
-  Meça a importância dos dados carregados pelas suas sessões e
-  tome medidas adicionais de proteção -- isto normalmente vem com um preço, menos
-  conveniência para o usuário. Por exemplo, se você quiser proteger os usuários
-  de táticas simples de engenharia social, você deve ativar
-  <literal>session.use_only_cookies</literal>. Neste caso,
+  Avalie a importância dos dados carregados pelas suas sessões e
+  tome medidas adicionais de proteção -- isto normalmente vem com um preço,
+  menos conveniência para o usuário.  Por exemplo, se você quiser
+  proteger os usuários de táticas simples de engenharia social, você deve
+  ativar <literal>session.use_only_cookies</literal>. Neste caso,
   os cookies devem estar ativados incondicionalmente do lado do usuário ou
   as sessões não irão funcionar.
  </para>
+
  <para>
-  Existem várias maneiras de vazar um id de uma sessão para terceiros.
-  Um id de sessão vazado permite a terceiros acessar a todos os recursos
-  que estão associados ao id específico. Primeiro, URLs carregando ids de sessão.
-  Se você criar um link com um site externo, a URL inclusa no id de sessão
-  deve ser guardada nos logs de referência do site externo. Segundo, um ataque mais
-  ativo pode escutar ao seu tráfego de rede. Se ele não for criptografado,
-  os ids de sessão irão passar como texto simples pela sua rede. A solução aqui
-  é implementar SSL em seu servidor e tornar obrigatório para os seus usuários.
+  Existem várias maneiras de vazar um ID de sessão para
+  terceiros. Um ID de sessão vazado permite a terceiros acessar todos
+  os recursos que estão associados ao ID específico. Primeiro, URLs
+  carregando IDs de sessão. Se você criar um link com um site externo, a URL
+  incluindo o ID de sessão pode ser guardada nos logs do
+  site externo. Segundo, um ataque mais ativo pode capturar seu
+  tráfego de rede. Se ele não for criptografado, os IDs de sessão irão passar como
+  texto simples pela rede. A solução aqui é implementar SSL
+  em seu servidor e tornar obrigatório para os usuários.  HSTS deve ser usado
+  para isto.
+ </para>
+
+ <para>
+  Desde o PHP 5.5.2, <link
+  linkend="ini.session.use-strict-mode">session.use_strict_mode</link>
+  está disponível. Quando estiver habilitado e o módulo de gravação o suportar,
+  ID de sessão não inicializado é rejeitado e um novo ID de sessão é
+  criado. Isso protege de ataques que forçam os usuários a utilizarem ID de sessão
+  conhecidos. Atacantes podem colar links ou enviar e-mails contendo o ID de
+  sessão. Por exemplo, http://example.com/page.php?PHPSESSID=123456789 Se <link
+  linkend="ini.session.use-trans-sid">session.use_trans_sid</link> estiver
+  habilitado, a vitima iniciará sessão usando o ID de sessão fornecido pelo
+  atacante.  <link
+  linkend="ini.session.use-strict-mode">session.use_strict_mode</link>
+  diminui o risco.
+ </para>
+
+ <para>
+  Apesar de <link
+  linkend="ini.session.use-strict-mode">session.use_strict_mode</link>
+  diminuir o risco da adoção do gerenciamento de sessão, o atacante pode forçar
+  os usuários a utilizarem um ID de sessão inicializado criado pelo
+  atacante. Tudo o que o atacante precisa fazer é iniciar o ID de sessão antes
+  do ataque e mantê-lo ativo.
+ </para>
+
+ <para>
+  Cookie de ID de sessão pode ser definido com os atributos domain, path, httponly e
+  secure. Existe uma precedência definida pelo browser. Com o uso da
+  precedência, o atacante pode definir o ID de sessão que poderia ser usado
+  permanentemente. O uso de <link
+  linkend="ini.session.use-only-cookies">session.use_only_cookies</link>
+  não resolverá essa questão. <link
+  linkend="ini.session.use-strict-mode">session.use_strict_mode</link>
+  diminui o risco. Com <link
+  linkend="ini.session.use-strict-mode">session.use_strict_mode</link>=On,
+  ID de sessão não inicializado não será aceito. O módulo de sessão
+  cria um novo ID de sessão sempre que o ID de sessão não é inicializado pelo
+  módulo de sessão. Isso poderia resultar em um ataque DoS para a vítima, mas DoS ainda é
+  melhor do que uma conta exposta.
+ </para>
+
+ <para>
+  <link
+  linkend="ini.session.use-strict-mode">session.use_strict_mode</link>
+  é uma boa forma de diminuir riscos, mas não é o suficiente para 
+  sessão autenticada. Desenvolvedores devem usar
+  <function>session_regenerate_id</function> para autenticação.
+  <function>session_regenerate_id</function> deve ser chamada antes de
+  definir informações de autenticação em
+  $_SESSION. <function>session_regenerate_id</function> garante que a nova
+  sessão contém informação de autenticação armazenadas apenas em uma nova
+  sessão. Isto é, erros durante o processo de autenticação podem salvar
+  informações de autenticação em sessão antiga.
+ </para>
+
+ <para>
+  Executar a função <function>session_regenerate_id</function> poderia
+  resultar em ataque DoS, da mesma forma que use_strict_mode=On. No entanto, DoS ainda é
+  melhor do que uma conta exposta. ID de sessão deve ser renovado
+  pelo menos quando o usuário fizer a autenticação. A renovação do ID de sessão reduz
+  o risco do roubo de ID de sessão, deste modo ela deve ser executada periodicamente.
+  O desenvolvedor não deve depender da expiração do ID de sessão. Atacantes podem
+  acessar o ID de sessão da vítima periodicamente para impedir que ele expire.
+  Desenvolvedores devem implementar seus próprios meios de expiração para sessões antigas.
+ </para>
+
+ <para>
+  Note que <function>session_regenerate_id</function> não apaga
+  sessão antiga por padrão. Sessão antiga de autenticação pode ficar disponível
+  para uso. Se o desenvolvedor quiser prevenir que sessão de autenticação antiga seja
+  usada por alguém, o desenvolvedor deve destruir a sessão definindo
+  <parameter>delete_old_session</parameter> como &true;. Contudo,
+  a eliminação de sessão antiga tem efeitos colaterais não desejados. A sessão
+  pode desaparecer quando houver conexões concorrentes em aplicações web
+  e/ou quando a rede estiver instável. Ao invés de apagar a sessão
+  antiga imediatamente, pode ser definido um tempo de expiração curto na
+  $_SESSION. Se o usuário acessar com uma sessão obsoleta
+  (uma sessão expirada), negue o acesso.
+ </para>
+
+ <para>
+  <link
+  linkend="ini.session.use-only-cookies">session.use_only_cookies</link>
+  e o uso adequado de <function>session_regenerate_id</function> poderiam
+  causar DoS individual. Quando este for o caso, pode ser solicitado aos usuários que
+  remova os cookies e alertá-los de que pode haver problemas de
+  segurança. Atacantes podem definir cookies maliciosos via aplivações web
+  vulneráveis (isto é, injeção de JavaScript), plugins vulneráveis/malicosos
+  para browsers, etc.
+ </para>
+
+ <para>
+  Desenvolvedores não devem utilizar ID de sessão de longa vida para login automático, pois
+  aumenta o risco de roubo de sessão. O login automático deve ser implementado
+  pelo desenvolvedor. Use chaves de hash descartáveis como chaves para o login automático através de
+  cookies. Use hash mais forte que SHA-2. Por exemplo, SHA-256 ou maior
+  com dados aleatórios de /dev/urandom ou similar. Se o usuário não estiver
+  autenticado, verifique se a chave descartável de login automática é válida ou não. Se
+  a chave é válida, autentique o usuário e defina uma nova chave de hash
+  descartável. A chave para login automático é uma chave de autenticação de longa duração, ela deve
+  estar o mais protegida possível. Use os atributos path/httponly/secure
+  dos cookies para proteção. O desenvolvedor deve implementar o recurso que
+  desabilita o login automático e remove chaves desnecessárias dos cookies dos
+  usuários.
  </para>
 </chapter>
 

--- a/pt_BR/reference/session/setup.xml
+++ b/pt_BR/reference/session/setup.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 297028 Maintainer: felipe Status: ready --><!-- CREDITS: fernandoc -->
+
 <chapter xml:id="session.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
@@ -9,13 +10,13 @@
   <note>
    <para>
     Opcionalmente você pode usar alocação de memória compartilhada (mm), desenvolvida por
-    Ralf S. Engelschall, para salvar a sessão. Você terá que baixar
-    <link xlink:href="&url.mm;">mm</link> e instalá-lo. esta opção não esta disponível
-    para plataformas Windows. Note que o módulo de sessões para o
-    mm não garante que acessos concorrentes a mesma sessão
-    sejam travados propriamente. Pode ser mais apropriado usar um sistema de arquivos
-    baseado em memória compartilhada (como tmpfs em Solaris/Linux, ou /dev/md em BSD) para
-    salvar sessões em arquivos, por que eles são propriamente travados.
+    Ralf S. Engelschall, para armazenar a sessão. Você terá que baixar
+    <link xlink:href="&url.mm;">mm</link> e instalá-lo. Esta opção não está
+    disponível para plataformas Windows. Note que o módulo de armazenamento de sessões para o
+    mm não garante que acessos concorrentes à mesma sessão
+    sejam travados apropriadamente. Pode ser mais apropriado usar um sistema de arquivos
+    baseado em memória compartilhada (como tmpfs em Solaris/Linux, ou <filename>/dev/md</filename> em BSD) para
+    armazenar sessões em arquivos, por que eles são travados apropriadamente.
     Os dados das sessões são salvos na memória então se o servidor for reiniciado os dados são excluídos.
    </para>
   </note>


### PR DESCRIPTION
Alterações realizadas:

- Adicionada a tag de revisão em alguns arquivos que estavam sem: book.xml, constants.xml, examples.xml, setup.xml;

- A tradução foi atualizada de acordo com a documentação original (EN);

- Melhoria em algumas frases que não sofreram alterações na documentação original (EN) mas estavam com erros de gramática, não faziam muito sentido ou a tradução estava confusa, exemplo:
	- examples.xml - "estão sujeitas ao mesmas limitações que as os nomes de variáveis regulares do PHP"
	- ini.xml - "<literal>session.auto_start</literal> especifíca se o módulo da sessão de executar automaticamente início da execução."
	- configure.xml - "Se você não gostaria de construir o seu PHP sem esse suporte, você especificaria a opção <option role="configure">--disable-session</option> para configurar"
