### PR TITLE
Atualização das traduções antigas de reference/session/functions/*.xml

### DIFF
--- a/pt_BR/reference/session/functions/session-cache-expire.xml
+++ b/pt_BR/reference/session/functions/session-cache-expire.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
-<refentry xml:id='function.session-cache-expire' xmlns="http://docbook.org/ns/docbook">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 303894 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id='function.session-cache-expire'>
  <refnamediv>
   <refname>session_cache_expire</refname>
   <refpurpose>Retorna o prazo do cache atual</refpurpose>
@@ -10,17 +10,18 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>session_cache_expire</methodname>
-   <methodparam choice="opt"><type>int</type><parameter>new_cache_expire</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>new_cache_expire</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>session_cache_expire</function> retorna a atual configuração de
+   <function>session_cache_expire</function> retorna a configuração atual de
    <literal>session.cache_expire</literal>.
   </para>
   <para>
-   O prazo para o cache expirar e retornado ao padrão de 180 minutos
-   guardado em <literal>session.cache_limiter</literal> no inicio do script.
-   Então você precisa usar <function>session_cache_expire</function> para
-   cada requesição (e antes que <function>session_start</function> seja utilizada).
+   O prazo para o cache expirar é redefinido para o padrão de 180 guardado em
+   <link linkend="ini.session.cache-expire">session.cache_expire</link>
+   na inicialização da requisição. Então
+   você precisa chamar <function>session_cache_expire</function> para cada
+   requesição (e antes que <function>session_start</function> seja utilizada).
   </para>
  </refsect1>
 
@@ -32,13 +33,13 @@
      <term><parameter>new_cache_expire</parameter></term>
      <listitem>
       <para>
-       Se <parameter>new_cache_expire</parameter> é dado, o cache atual
-       é modificado por <parameter>new_cache_expire</parameter>.
+       Se <parameter>new_cache_expire</parameter> é informado, o prazo atual
+       é modificado para <parameter>new_cache_expire</parameter>.
       </para>
       <para>
        <note>
         <simpara>
-         Defina o valor de <parameter>new_cache_expire</parameter>, somente se
+         Definir o valor de <parameter>new_cache_expire</parameter> somente importa se
          <literal>session.cache_limiter</literal> é definido como um valor
          <emphasis>diferente</emphasis> de <literal>nocache</literal>.
         </simpara>
@@ -54,7 +55,7 @@
   &reftitle.returnvalues;
   <para>
    Retorna a configuração atual de <literal>session.cache_expire</literal>.
-   O valor retornado deve ser lido em minutos, padrão para 180. 
+   O valor retornado deve ser lido em minutos, padrão de 180. 
   </para>
  </refsect1>
 
@@ -62,23 +63,26 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemplo da <function>session_cache_expire</function></title>
+    <title>Exemplo de <function>session_cache_expire</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
 
-/* Define o limitador de cache para 'private' */
+/* define o limitador de cache para 'private' */
+
 session_cache_limiter('private');
 $cache_limiter = session_cache_limiter();
 
-/* Define o limite de tempo do cache em 30 minutos */
+/* define o prazo do cache em 30 minutos */
 session_cache_expire(30);
 $cache_expire = session_cache_expire();
 
-/* Inicia a sessão */
+/* inicia a sessão */
+
 session_start();
-echo "O limitador de cache esta definido agora como $cache_limiter<br />"; 
-echo "As sessões em cache irão expirar em $cache_expire minutos";
+
+echo "O limitador de cache está definido agora como $cache_limiter<br />"; 
+echo "As sessões em cache irão expirar depois de $cache_expire minutos";
 ?>
 ]]>
     </programlisting>

--- a/pt_BR/reference/session/functions/session-cache-limiter.xml
+++ b/pt_BR/reference/session/functions/session-cache-limiter.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
-<refentry xml:id="function.session-cache-limiter" xmlns="http://docbook.org/ns/docbook">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 334605 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-cache-limiter">
  <refnamediv>
   <refname>session_cache_limiter</refname>
   <refpurpose>Obtém e/ou define o limitador do cache atual</refpurpose>
@@ -17,25 +17,30 @@
    limitador do cache.
   </para>
   <para>
-   O limitador do cache controla HTTP headers enviados para o cliente.
-   Estes headers determinam pelas quais o conteúdo da página pode ser guardado no 
-   cache. Definindo o limitador do cache para <literal>nocache</literal>,
-   por exemplo, rejeitaria qualquer armazenamento no cache do cliente.  Um valor 
-   como <literal>public</literal>, entretanto, permitiria o armazenamento no cache.  
-   Ele também poderia ser definido como <literal>private</literal>, que é um pouco 
-   mais restritivo do que <literal>public</literal>.
+   O limitador do cache controla quais HTTP headers de controle de cache são enviados para
+   o cliente.  Estes headers determinam as regras pelas quais o conteúdo da página
+   pode ser guardado em cache pelo cliente e proxy intermediário.  Definindo o limitador do
+   cache para <literal>nocache</literal> rejeitaria qualquer cache do cliente/proxy.
+   Um valor como <literal>public</literal> permitiria o cache do proxy e do
+   cliente, e <literal>private</literal> rejeitaria o cache do proxy 
+   mas permite que o cliente armazene o conteúdo em cache.
   </para>
   <para>
-   No modo <literal>private</literal> , Header expirado enviado para o cliente, 
-   pode provocar confusão para alguns para alguns navegadores incluindo o Mozilla. 
-   Você pode evitar este problema com o modo <literal>private_no_expire</literal>.
-   Header expirado nunca é enviado para o cliente nesse modo.
+   No modo <literal>private</literal>, o cabeçalho Expire enviado para o cliente
+   pode provocar confusão em alguns browsers, incluindo o <productname>Mozilla</productname>.
+   Você pode evitar este problema usando o modo <literal>private_no_expire</literal>. O
+   cabeçalho <literal>Expire</literal> nunca é enviado para o cliente nesse modo.
   </para>
   <para>
-   O limitador do cache é zerado para o valor padrão guardado em
-   <link linkend="ini.session.cache-limiter">session.cache_limiter</link> no pedido do startup time. Assim,
-   você precisa chamar <function>session_cache_limiter</function> para cada
-   pedido (e antes <function>session_start</function> é chamada).
+   Definindo o limitador do cache como <literal>''</literal> desativará completamente o envio automático
+   de cabeçalhos de cache.
+  </para>
+  <para>
+   O limitador do cache é redefinido para o valor padrão guardado em
+   <link linkend="ini.session.cache-limiter">session.cache_limiter</link>
+   na inicialização da requisição. Então você precisa chamar
+   <function>session_cache_limiter</function> para cada
+   requisição (e antes que <function>session_start</function> seja chamada).
   </para>
  </refsect1>
 
@@ -48,8 +53,68 @@
      <listitem>
       <para>
        Se <parameter>cache_limiter</parameter> é especificado, o nome do
-       atual limitador de cache é modificado para o novo valor.
+       limitador de cache atual é modificado para o novo valor.
       </para>
+      <table>
+       <title>Valores possíveis</title>
+       <tgroup cols="2">
+        <thead>
+         <row>
+          <entry>Valor</entry>
+          <entry>Cabeçalhos enviados</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry><literal>public</literal></entry>
+          <entry>
+           <programlisting role="header">
+<![CDATA[
+Expires: (em algum momento do futuro, de acordo com session.cache_expire)
+Cache-Control: public, max-age=(em algum momento do futuro, de acordo com session.cache_expire)
+Last-Modified: (o timestamp de quando a sessão foi salva pela última vez)
+]]>
+           </programlisting>
+          </entry>
+         </row>
+         <row>
+          <entry><literal>private_no_expire</literal></entry>
+          <entry>
+           <programlisting role="header">
+<![CDATA[
+Cache-Control: private, max-age=(session.cache_expire no futuro), pre-check=(session.cache_expire no futuro)
+Last-Modified: (o timestamp de quando a sessão foi salva pela última vez)
+]]>
+           </programlisting>
+          </entry>
+         </row>
+         <row>
+          <entry><literal>private</literal></entry>
+          <entry>
+           <programlisting role="header">
+<![CDATA[
+Expires: Thu, 19 Nov 1981 08:52:00 GMT
+Cache-Control: private, max-age=(session.cache_expire no futuro), pre-check=(session.cache_expire no futuro)
+Last-Modified: (o timestamp de quando a sessão foi salva pela última vez)
+]]>
+           </programlisting>
+          </entry>
+         </row>
+         <row>
+          <entry><literal>nocache</literal></entry>
+          <entry>
+           <programlisting role="header">
+<![CDATA[
+Expires: Thu, 19 Nov 1981 08:52:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+Pragma: no-cache
+]]>
+           </programlisting>
+          </entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -59,46 +124,25 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna o nome do atual limitador de cache. 
+   Retorna o nome do limitador de cache atual.
   </para>
  </refsect1>
-
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>4.2.0</entry>
-       <entry>
-        O limitador do cache <literal>private_no_expire</literal> foi adicionado.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1> 
 
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-  <example>
-   <title>Exemplo da <function>session_cache_limiter</function></title>
-   <programlisting role="php">
+   <example>
+    <title>Exemplo de <function>session_cache_limiter</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
-/* Defini o limitador do cache para 'private' */
+
+/* define o limitador do cache para 'private' */
+
 session_cache_limiter('private');
 $cache_limiter = session_cache_limiter();
-echo "o limitador do cache está definido agora para $cache_limiter<br />";
+
+echo "O limitador do cache está definido agora para $cache_limiter<br />";
 ?>
 ]]>
     </programlisting>
@@ -108,7 +152,7 @@ echo "o limitador do cache está definido agora para $cache_limiter<br />";
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para> 
+  <para>
    <simplelist>
     <member><link linkend="ini.session.cache-limiter">session.cache_limiter</link></member>
    </simplelist>

--- a/pt_BR/reference/session/functions/session-commit.xml
+++ b/pt_BR/reference/session/functions/session-commit.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 297028 Maintainer: felipe Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-commit">
  <refnamediv>

--- a/pt_BR/reference/session/functions/session-decode.xml
+++ b/pt_BR/reference/session/functions/session-decode.xml
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 297028 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
-<refentry xml:id="function.session-decode" xmlns="http://docbook.org/ns/docbook">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 339181 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-decode">
  <refnamediv>
   <refname>session_decode</refname>
-  <refpurpose>Decifra dado de sessão de uma string</refpurpose>
+  <refpurpose>Decodifica dados de sessão de uma sessão codificada em formato string</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">
@@ -13,9 +13,13 @@
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>session_decode</function> decifra dado de sessão em
-   <parameter>data</parameter>, definindo variáveis guardadas na
-   sessão.
+   <function>session_decode</function> decodifica os dado de sessão serializados fornecidos em
+   <parameter>$data</parameter> e preenche a super global $_SESSION
+   com o resultado.
+  </para>
+  <para>
+   Por padrão, o método de deserialização usado é interno do PHP e não é o mesmo que <function>unserialize</function>.
+   O método de deserialização pode ser configurado usando <link linkend="ini.session.serialize-handler">session.serialize_handler</link>.
   </para>
  </refsect1>
 
@@ -27,7 +31,7 @@
      <term><parameter>data</parameter></term>
      <listitem>
       <para>
-       A informação codificada para ser armazenada.
+       Os dados codificados para serem armazenados.
       </para>
      </listitem>
     </varlistentry>
@@ -47,6 +51,7 @@
   <para>
    <simplelist>
     <member><function>session_encode</function></member>
+    <member><link linkend="ini.session.serialize-handler">session.serialize_handler</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/pt_BR/reference/session/functions/session-destroy.xml
+++ b/pt_BR/reference/session/functions/session-destroy.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
-<refentry xml:id="function.session-destroy" xmlns="http://docbook.org/ns/docbook">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 297028 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-destroy">
  <refnamediv>
   <refname>session_destroy</refname>
   <refpurpose>Destrói todos os dados registrados em uma sessão</refpurpose>
@@ -13,14 +13,16 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   <function>session_destroy</function> destrói todos os dados associados com a 
-   sessão atual. Ela não desregistra nenhuma das variáveis globais associadas a 
-   sessão atual, nem desregistra o cookie de sessão.
+   <function>session_destroy</function> destrói todos os dados associados com a
+   sessão atual. Ela não apaga nenhuma das variáveis globais
+   associadas a sessão atual, nem apaga o cookie de sessão.
+   Para usar as variáveis de sessão novamente, <function>session_start</function> tem
+   que ser chamada.
   </simpara>
   <para>
-   Para poder matar a sessão junto, como para fazer o log out do usuário, 
-   o id da sessão também deve ser desregistrado. Se for usado um cookie para propagar o
-   id de sessão (funcionamento padrão), então o cookie de sessão deve ser excluído.  
+   Para matar a sessão também, como para fazer o log out do usuário, o
+   id da sessão também deve ser apagado. Se um cookie for usado para propagar o
+   id de sessão (funcionamento padrão), então o cookie de sessão deve ser excluído.
    <function>setcookie</function> pode ser usado para isso.
   </para>
  </refsect1>
@@ -40,20 +42,24 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// Initialize the session.
-// If you are using session_name("something"), don't forget it now!
+// Inicializa a sessão.
+// Se estiver sendo usado session_name("something"), não esqueça de usá-lo agora!
 session_start();
 
-// Unset all of the session variables.
+// Apaga todas as variáveis da sessão
 $_SESSION = array();
 
-// If it's desired to kill the session, also delete the session cookie.
-// Note: This will destroy the session, and not just the session data!
-if (isset($_COOKIE[session_name()])) {
-    setcookie(session_name(), '', time()-42000, '/');
+// Se é preciso matar a sessão, então os cookies de sessão também devem ser apagados.
+// Nota: Isso destruirá a sessão, e não apenas os dados!
+if (ini_get("session.use_cookies")) {
+    $params = session_get_cookie_params();
+    setcookie(session_name(), '', time() - 42000,
+        $params["path"], $params["domain"],
+        $params["secure"], $params["httponly"]
+    );
 }
 
-// Finally, destroy the session.
+// Finalmente, destrói a sessão
 session_destroy();
 ?>
 ]]>
@@ -66,7 +72,7 @@ session_destroy();
   &reftitle.notes;
   <note>
    <para>
-    Apenas use <function>session_unset</function> para código antigo obsoleto
+    Somente use <function>session_unset</function> para código antigo/obsoleto
     que não use <varname>$_SESSION</varname>.
    </para>
   </note>

--- a/pt_BR/reference/session/functions/session-encode.xml
+++ b/pt_BR/reference/session/functions/session-encode.xml
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 297028 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 339181 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
 <refentry xml:id="function.session-encode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>session_encode</refname>
-  <refpurpose>Codifica os dados da sessão atual como uma string</refpurpose>
+  <refpurpose>Codifica os dados atuais da sessão como uma sessão codificada em formato string</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">
@@ -13,23 +13,37 @@
    <void/>
   </methodsynopsis>
   <para>
-   <function>session_encode</function> retorna uma string com o
-   conteúdo da sessão corrente codificado em seu interior.
+   <function>session_encode</function> retorna uma string serializada do
+   conteúdo atual da sessão armazenados na super global $_SESSION.
+  </para>
+  <para>
+   Por padrão, o método de serialização usado é interno do PHP e não é o mesmo que <function>serialize</function>.
+   O método de serialização pode ser configurado usando <link linkend="ini.session.serialize-handler">session.serialize_handler</link>.
   </para>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna codificado o conteúdo da sessão atual.
+   Retorna, codificado, o conteúdo da sessão atual.
   </para>
  </refsect1>
 
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <warning>
+   <para>
+    Must call <function>session_start</function> before using <function>session_encode</function>.
+   </para>
+  </warning>
+ </refsect1> 
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
    <simplelist>
     <member><function>session_decode</function></member>
+    <member><link linkend="ini.session.serialize-handler">session.serialize_handler</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/pt_BR/reference/session/functions/session-get-cookie-params.xml
+++ b/pt_BR/reference/session/functions/session-get-cookie-params.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
-<refentry xml:id="function.session-get-cookie-params" xmlns="http://docbook.org/ns/docbook">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 334592 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-get-cookie-params">
  <refnamediv>
   <refname>session_get_cookie_params</refname>
   <refpurpose>Obtém os parâmetros do cookie da sessão</refpurpose>
@@ -13,39 +13,44 @@
    <void/>
   </methodsynopsis>
   <para>
-   Obtém parâmetros do cookie da sessão.
+   Obtém os parâmetros do cookie da sessão.
   </para>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna um array com informação do cookie da sessão atual, o array contém 
+   Retorna um array com informação do cookie da sessão atual. O array contém 
    os seguintes items:
    <itemizedlist>
     <listitem>
      <simpara>
-      "lifetime" -  A duração do cookie em segundos.
+      <link linkend="ini.session.cookie-lifetime">"lifetime"</link> -  A
+      duração do cookie em segundos.
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "path" -  O caminho onde a informação está guardada.
+      <link linkend="ini.session.cookie-path">"path"</link> -  O caminho onde
+      a informação está armazenada.
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "domain" -  O domínio do cookie.
+      <link linkend="ini.session.cookie-domain">"domain"</link> -  O domínio
+      do cookie.
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "secure" -  O cookie seria enviado apenas sobre conexões seguras.
+      <link linkend="ini.session.cookie-secure">"secure"</link> -  O cookie
+      deve ser enviado apenas em conexões seguras.
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      "httponly" - O cookie somente pode ser acessado atráves do protocolo HTTP.
+      <link linkend="ini.session.cookie-httponly">"httponly"</link> - O
+      cookie pode ser acessado somente atráves do protocolo HTTP.
      </simpara>
     </listitem>
    </itemizedlist>
@@ -70,12 +75,6 @@
         A entrada "httponly" foi adicionada no array retornado.
        </entry>
       </row>
-      <row>
-       <entry>4.0.4</entry>
-       <entry>
-        A entrada "secure" foi adicionada no array retornado.
-       </entry>
-      </row>
      </tbody>
     </tgroup>
    </informaltable>
@@ -91,7 +90,6 @@
     <member><link linkend="ini.session.cookie-domain">session.cookie_domain</link></member>
     <member><link linkend="ini.session.cookie-secure">session.cookie_secure</link></member>
     <member><link linkend="ini.session.cookie-httponly">session.cookie_httponly</link></member>
-    <member><link linkend="ini.session.cookie-lifetime">session.cookie_lifetime</link></member>
     <member><function>session_set_cookie_params</function></member>
    </simplelist>
   </para>

--- a/pt_BR/reference/session/functions/session-id.xml
+++ b/pt_BR/reference/session/functions/session-id.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
-<refentry xml:id="function.session-id" xmlns="http://docbook.org/ns/docbook">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 334621 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-id">
  <refnamediv>
   <refname>session_id</refname>
   <refpurpose>Obtém e/ou define o id de sessão atual</refpurpose>
@@ -17,7 +17,7 @@
   </para>
   <para>
    A constante <systemitem>SID</systemitem> também pode ser usada para
-   obter o nome atual e o id da sessão como uma string adequado para
+   obter o nome e id da sessão atual como uma string adequado para
    adicionar em URLs. Veja também <link linkend="ref.session">Manipulação
    de Sessão</link>.
   </para>
@@ -31,19 +31,19 @@
      <term><parameter>id</parameter></term>
       <listitem>
        <para>
-        Se <parameter>id</parameter> for especificado, ele irá substituir o
-        id de sessão atual. <function>session_id</function> precisa ser chamado
-        antes de <function>session_start</function> para este fim. Dependendo do manipulador
-        de sessão, nem todos os caracteres são permitidos em um id de sessão.
-        Por exemplo, o manipulador de sessão em arquivo permite apenas caracteres
-        no intervalo <literal>a-z, A-Z and 0-9</literal>!
+        Se <parameter>id</parameter> for especificado, ele substituirá o
+        id de sessão atual. <function>session_id</function> precisa ser chamado antes de
+        <function>session_start</function> para este fim. Dependendo do
+        manipulador de sessão, nem todos os caracteres são permitidos em um id de sessão.
+        Por exemplo, o manipulador de sessão em arquivo permite apenas caracteres no
+        intervalo <literal>a-z A-Z 0-9 , (comma) and - (minus)</literal>!
        </para>
        <note>
         <simpara>
          Quando estiver usando cookies de sessão, especificar um <parameter>id</parameter>
-         para <function>session_id</function> irá sempre enviar um novo cookie quando
-         <function>session_start</function> for chamada, sem importar se
-         o id da sessão atual for identico ao que esta sendo definido.
+         para <function>session_id</function> sempre enviará um novo cookie
+         quando <function>session_start</function> for chamada, sem importar se o
+         id da sessão atual for idêntico ao que está sendo definido.
         </simpara>
        </note>
       </listitem>

--- a/pt_BR/reference/session/functions/session-is-registered.xml
+++ b/pt_BR/reference/session/functions/session-is-registered.xml
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
-<refentry xml:id="function.session-is-registered" xmlns="http://docbook.org/ns/docbook">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 323674 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-is-registered">
  <refnamediv>
   <refname>session_is_registered</refname>
-  <refpurpose>Descobre se uma variável global está registrada numa sessão</refpurpose>
+  <refpurpose>Verifica se uma variável global está registrada numa sessão</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">
@@ -13,8 +13,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Verifica se há uma variável global é registrada na sessão.
+   Verifica se uma variável global está registrada numa sessão.
   </para>
+  &warn.deprecated.function-5-3-0.removed-5-4-0;
  </refsect1>
 
  <refsect1 role="parameters">
@@ -46,16 +47,18 @@
   &reftitle.notes;
   <note>
    <para>
-    Se <varname>$_SESSION</varname> (ou <varname>$HTTP_SESSION_VARS</varname> para
-    PHP 4.0.6 ou inferior) é usada, use <function>isset</function> para checar se 
+    Se <varname>$_SESSION</varname> (ou <varname>$HTTP_SESSION_VARS</varname>
+    para PHP 4.0.6 ou inferior) é usada, use <function>isset</function> para checar se 
     uma variável está registrada em <varname>$_SESSION</varname>.
    </para>
   </note>
   <caution>
    <para>
-    Se você está usando <varname>$_SESSION</varname> (ou <varname>$HTTP_SESSION_VARS</varname>),
-    não utilize <function>session_register</function>,
-    <function>session_is_registered</function> e <function>session_unregister</function>.
+    Se você está usando <varname>$_SESSION</varname>
+    (ou <varname>$HTTP_SESSION_VARS</varname>), não utilize
+    <function>session_register</function>,
+    <function>session_is_registered</function> e
+    <function>session_unregister</function>.
    </para>
   </caution>
  </refsect1>

--- a/pt_BR/reference/session/functions/session-module-name.xml
+++ b/pt_BR/reference/session/functions/session-module-name.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 297028 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
-<refentry xml:id="function.session-module-name" xmlns="http://docbook.org/ns/docbook">
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-module-name">
  <refnamediv>
   <refname>session_module_name</refname>
   <refpurpose>Obtém e/ou define o módulo da sessão atual</refpurpose>
@@ -13,7 +13,8 @@
    <methodparam choice="opt"><type>string</type><parameter>module</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>session_module_name</function> obtém o nome do módulo da sessão atual.
+   <function>session_module_name</function> obtém o nome do módulo da
+   sessão atual.
   </para>
  </refsect1>
 
@@ -25,7 +26,7 @@
      <term><parameter>module</parameter></term>
      <listitem>
       <para>
-       Se <parameter>module</parameter> é especificado, este módulo será
+       Se <parameter>module</parameter> é especificado, então é este módulo que será
        usado.
       </para>
      </listitem>
@@ -37,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retorna o do módulo da sessão atual.
+   Retorna o nome do módulo da sessão atual.
   </para>
  </refsect1>
 

--- a/pt_BR/reference/session/functions/session-name.xml
+++ b/pt_BR/reference/session/functions/session-name.xml
@@ -1,59 +1,104 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: fernandoc Status: ready -->
-<!-- CREDITS: surfmax -->
-<!-- splitted from ./en/functions/session.xml, last change in rev 1.2 -->
-  <refentry xml:id="function.session-name" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>session_name</refname>
-    <refpurpose>Obtém e/ou define o nome da sessão atual</refpurpose>
-   </refnamediv>
-   <refsect1>
-    <title>Descrição</title>
-     <methodsynopsis>
-      <type>string</type><methodname>session_name</methodname>
-      <methodparam choice="opt"><type>string</type><parameter>name</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     <function>session_name</function> retorna o nome da sessão atual.
-     Se <parameter>name</parameter> está especificado, o nome da sessão
-     atual é mudado para esse valor.
-    </para>
-    <para>
-     O nome da sessão refere-se à id de sessão em cookies e URLs.
-     Ela poderia conter apenas caracteres alfanuméricos; ela poderia
-    ser curta e descritiva (i.e. para usuários com avisos em cookie 
-    habilitados). O nome da sessão é retomado para o valor padrão 
-     guardado em <literal>session.name</literal> no pedido na hora de 
-     inicialização. Dessa forma, você precisa chamar <function>session_name</function>
-     para cada requerimento (e antes de <function>session_start</function>
-     ou <function>session_register</function> serem chamadas).
-    </para>
-    <warning>
-     <para>
-      O nome da sessão não pode consistir apenas de digitos, ao menos uma letra
-      deve estar presente. Se não, um novo id de sessão é gerado a cada vez.
-     </para>
-    </warning>
-    <example>
-     <title>Exemplos <function>session_name</function></title>
-     <programlisting role="php">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 336796 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-name">
+ <refnamediv>
+  <refname>session_name</refname>
+  <refpurpose>Obtém e/ou define o nome da sessão atual</refpurpose>
+ </refnamediv>
+ 
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>session_name</methodname>
+   <methodparam choice="opt"><type>string</type><parameter>name</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>session_name</function> retorna o nome da sessão
+   atual. Se <parameter>name</parameter> é informado,
+   <function>session_name</function> vai atualizar o nome da sessão e retornar
+   o nome da sessão <emphasis>antiga</emphasis>.
+  </para>
+  <para>
+    O nome da sessão é redefinido para o padrão guardado em
+    <literal>session.name</literal> na inicialização da requisição. Então você deve
+    chamar <function>session_name</function> para cada requisição (e antes que
+    <function>session_start</function> ou <function>session_register</function>
+    sejam chamadas).
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>name</parameter></term>
+     <listitem>
+      <para>
+       O nome da sessão refere-se ao nome da sessão, que é
+       usado em cookies e URLs (por exemplo, <literal>PHPSESSID</literal>). Ele
+       deve conter apenas caracteres alfanuméricos; ele deve ser curto e
+       descritivo (para usuários com avisos de cookie habilitados).
+       Se <parameter>name</parameter> é informado, o nome da sessão
+       atual é modificado para o novo valor.
+      </para>
+      <para>
+       <warning>
+        <para>
+         O nome da sessão não pode consistir apenas de dígitos, pelo menos uma letra
+         deve estar presente. Caso contrário um novo id de sessão é gerado toda vez.
+        </para>
+       </warning>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retorna o nome da sessão atual. Se <parameter>name</parameter> é informado
+   e a função atualizar o nome da sessão, o nome da sessão <emphasis>antiga</emphasis>
+   é retornado.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Exemplo de <function>session_name</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 
-// defina o nome da sessão para WebsiteID
+/* defina o nome da sessão para WebsiteID */
 
 $previous_name = session_name("WebsiteID");
 
 echo "O nome da sessão anterior era $previous_name<br />";
 ?>
 ]]>
-     </programlisting>
-    </example>
-    <para> 
-      Veja também a diretiva de configurção <link linkend="ini.session.name">session.name</link>.
-    </para>
-   </refsect1>
-  </refentry>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member>
+     <link linkend="ini.session.name">session.name</link> (diretiva de
+     configuração)
+    </member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/pt_BR/reference/session/functions/session-regenerate-id.xml
+++ b/pt_BR/reference/session/functions/session-regenerate-id.xml
@@ -1,86 +1,90 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: fernandoc Status: ready -->
-<refentry xml:id="function.session-regenerate-id" xmlns="http://docbook.org/ns/docbook">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 332711 Maintainer: fernandoc Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-regenerate-id">
  <refnamediv>
   <refname>session_regenerate_id</refname>
   <refpurpose>
-   Atualiza o id da sessão atual com um novo gerado
+   Atualiza o id da sessão atual com um novo id gerado
   </refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-   <methodsynopsis>
-    <type>bool</type><methodname>session_regenerate_id</methodname>
-    <methodparam choice="opt"><type>bool</type><parameter>delete_old_session</parameter></methodparam>
-   </methodsynopsis>
+  <methodsynopsis>
+   <type>bool</type><methodname>session_regenerate_id</methodname>
+   <methodparam choice="opt"><type>bool</type><parameter>delete_old_session</parameter><initializer>false</initializer></methodparam>
+  </methodsynopsis>
   <para>
-   <function>session_regenerate_id</function> irá substituiro id
-   da seção atual com um novo, e mantém a informação da sessão atual.
+   <function>session_regenerate_id</function> substituirá o id da seção
+   atual com um novo id e manter a informação da sessão atual.
+  </para>
+  <para>
+   Quando <link linkend="ini.session.use-trans-sid">session.use_trans_sid</link>
+   estiver habilitada, saídas (output) devem ser iniciadas depois de <function>session_regenerate_id</function>
+   ser chamada. Caso contrário, o ID da sessão antiga é utilizado.
   </para>
  </refsect1>
 
-<refsect1 role="parameters">
- &reftitle.parameters;
- <para>
-  <variablelist>
-   <varlistentry>
-    <term><parameter>delete_old_session</parameter></term>
-    <listitem>
-     <para>
-      Quando excluir o arquivo associado a sessão anterior ou não. O padrão é
-      &false;.
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
- </para>
-</refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>delete_old_session</parameter></term>
+      <listitem>
+       <para>
+        Se o arquivo associado à sessão anterior deve ser excluído ou não.
+       </para>
+      </listitem>
+     </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
 
-<refsect1 role="returnvalues">
- &reftitle.returnvalues;
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
-   </refsect1>
+ </refsect1>
 
-<refsect1 role="changelog">
- &reftitle.changelog;
- <para>
-  <informaltable>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>&Version;</entry>
-      <entry>&Description;</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-     <entry>4.3.3</entry>
-     <entry>
-      Desde então, se os cookies de sessão estão ativos, o uso de
-      <function>session_regenerate_id</function> irá também enviar um novo
-      cookie de sessão com o novo id de sessão.
-     </entry>
-     </row>
-     <row>
-     <entry>5.1.0</entry>
-     <entry>
-      Adicionado o parâmetro <parameter>delete_old_session</parameter>.
-     </entry>
-    </row>
-    </tbody>
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>4.3.3</entry>
+       <entry>
+        Desde então, se os cookies de sessão estão ativos, o uso de
+        <function>session_regenerate_id</function> também enviará um novo
+        cookie de sessão com o novo id de sessão.
+       </entry>
+      </row>
+      <row>
+       <entry>5.1.0</entry>
+       <entry>
+        Adicionado o parâmetro <parameter>delete_old_session</parameter>.
+       </entry>
+      </row>
+     </tbody>
     </tgroup>
    </informaltable>
   </para>
  </refsect1>
 
  <refsect1 role="examples">
- &reftitle.examples;
+  &reftitle.examples;
   <para>
    <example>
-    <title>Exemplo <function>session_regenerate_id</function></title>
+    <title>Exemplo de <function>session_regenerate_id</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -92,8 +96,8 @@ session_regenerate_id();
 
 $new_sessionid = session_id();
 
-echo "Old Session: $old_sessionid<br />";
-echo "New Session: $new_sessionid<br />";
+echo "Sessão antiga: $old_sessionid<br />";
+echo "Sessão nova: $new_sessionid<br />";
 
 print_r($_SESSION);
 ?>
@@ -102,8 +106,9 @@ print_r($_SESSION);
    </example>
   </para>
  </refsect1>
+
  <refsect1 role="seealso">
- &reftitle.seealso;
+  &reftitle.seealso;
   <para>
    <simplelist>
     <member><function>session_id</function></member>

--- a/pt_BR/reference/session/functions/session-register.xml
+++ b/pt_BR/reference/session/functions/session-register.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 323674 Maintainer: ae Status: ready --><!-- CREDITS: surfmax,fernandoc,ae -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-register">
  <refnamediv>
@@ -14,39 +14,39 @@
    <methodparam choice="opt"><type>mixed</type><parameter>...</parameter></methodparam>
   </methodsynopsis>
   <para>
-  <function>session_register</function> aceita um número de argumentos
-   variáveis, alguns deles podem ser ou uma string com o nome da variável
-   ou uma matriz de nomes de variáveis ou outras matrizes. Para cada nome,
-   <function>session_register</function> registra a variável
+   <function>session_register</function> aceita um número de argumentos
+   variáveis, alguns deles podem ser ou uma string com o nome da
+   variável ou um array de nomes de variáveis ou outros arrays. Para
+   cada nome, <function>session_register</function> registra a variável
    global com o nome na sessão atual.
   </para>
   <para>
-   Você também pode criar uma variável de sessão simplesmente anexando
-   um membro nos arrays <varname>$_SESSION</varname>
+   Você também pode criar uma variável de sessão simplesmente definindo o
+   membro apropriado nos arrays <varname>$_SESSION</varname>
    ou <varname>$HTTP_SESSION_VARS</varname> (PHP &lt; 4.1.0).
    <informalexample>
     <programlisting role="php">
 <![CDATA[
 <?php
 // O uso de session_register() está obsoleto
-$barney = "A big purple dinosaur.";
+$barney = "Um grande dinossauro roxo.";
 session_register("barney");
 
-// Uso de $_SESSION é preferível desde o PHP 4.1.0
-$_SESSION["zim"] = "An invader from another planet.";
+// O uso de $_SESSION é preferível desde o PHP 4.1.0
+$_SESSION["zim"] = "Um invasor de outro planeta.";
 
-// The old way was to use $HTTP_SESSION_VARS
-$HTTP_SESSION_VARS["spongebob"] = "He's got square pants.";
+// O modo antigo era usando $HTTP_SESSION_VARS
+$HTTP_SESSION_VARS["spongebob"] = "Ele tem uma calça quadrada.";
 ?>
 ]]>
     </programlisting>
    </informalexample>
   </para>
   <para>
-   Se <function>session_start</function> não foi chamado antes dessa
-   função, uma chamada implícita a <function>session_start</function> será feita,
-   sem parâmetros. <varname>$_SESSION</varname> não imita esse
-   comportamento e requer uma chamada a<function>session_start</function> antes de seu uso.
+   Se <function>session_start</function> não for chamada antes dessa função
+   ser executada, uma chamada implícita a <function>session_start</function>, sem
+   parâmetros, será feita.  <varname>$_SESSION</varname> não imita
+   esse comportamento e requer <function>session_start</function> antes de seu uso.
   </para>
   &warn.deprecated.function-5-3-0.removed-5-4-0;
  </refsect1>
@@ -59,8 +59,8 @@ $HTTP_SESSION_VARS["spongebob"] = "He's got square pants.";
      <term><parameter>name</parameter></term>
      <listitem>
       <para>
-       Uma string contento o nome de uma variável ou array com nome
-       de variáveis ou ainda outros arrays.
+       Uma string contento o nome de uma variável ou array com nomes de
+       variáveis ou ainda outros arrays.
       </para>
      </listitem>
     </varlistentry>
@@ -86,11 +86,11 @@ $HTTP_SESSION_VARS["spongebob"] = "He's got square pants.";
   &reftitle.notes;
   <caution>
    <para>
-    Se você deseja que seu script funcione independente de<link
-    linkend="ini.register-globals">register_globals</link>, você precisa
-    utilizar <varname>$_SESSION</varname> pois
-    assim os dados contidos em <varname>$_SESSION</varname> serão automaticamente registrados. Se
-    o seu script utiliza<function>session_register</function>, ele não irá funcionar
+    Se você deseja que seu script funcione independente de <link
+    linkend="ini.register-globals">register_globals</link>, então o que deve ser
+    usado é o array <varname>$_SESSION</varname>, pois entradas em
+    <varname>$_SESSION</varname> são registrados automaticamente. Se
+    o seu script utiliza <function>session_register</function>, ele não vai funcionar
     em ambientes onde a diretava <link
     linkend="ini.register-globals">register_globals</link> está desativada.
    </para>
@@ -99,17 +99,17 @@ $HTTP_SESSION_VARS["spongebob"] = "He's got square pants.";
   <caution>
    <para>
     Isto registra uma variável <emphasis>global</emphasis>. Se você deseja
-    registrar uma variável de dentro de uma função então é ncessário
-    torná-la global utilizando a instrução <link
+    registrar uma variável de dentro de uma função, então é necessário
+    torná-la global utilizando a keyword <link
     linkend="language.variables.scope"><command>global</command></link>
-    ou o array <varname>$GLOBALS[]</varname>, ou ainda utilizar os
-    arrays especiais conforme abaixo.
+    ou o array <varname>$GLOBALS[]</varname>, ou ainda utilizar os arrays
+    especiais conforme abaixo.
    </para>
   </caution>
   <caution>
    <para>
     Se você está utilizando <varname>$_SESSION</varname>
-    (ou <varname>$HTTP_SESSION_VARS</varname>) então não use
+    (ou <varname>$HTTP_SESSION_VARS</varname>), então não use
     <function>session_register</function>,
     <function>session_is_registered</function> e
     <function>session_unregister</function>.
@@ -117,18 +117,19 @@ $HTTP_SESSION_VARS["spongebob"] = "He's got square pants.";
   </caution>
   <note>
    <para>
-    Atualmente é impossível registrar variáveis com resources em uma sessão.
-    Por exemplo você não pode criar uma conexão a um banco de dados e armazenar
-    a conexão numa variável de sessão e esperar que a conexão ainda esteja
-    válida quando a sessão for restaurada. Funções do PHP que retornam um
-    recurso são identificados pelo tipo
-    <literal>resource</literal> em sua definição. Uma lista de
+    Atualmente é impossível registrar variáveis de recursos (resource) em uma sessão.
+    Por exemplo, você não pode criar uma conexão a um banco de dados e armazenar a
+    conexão em uma variável de sessão e esperar que a conexão ainda esteja
+    válida quando a sessão for restaurada.  Funções do PHP que retornam um
+    recurso (resource) são identificados pelo tipo
+    <literal>resource</literal> em sua definição.  Uma lista de
     funções que retornam recursos está disponível no apêndice <link
     linkend="resource">Tipos de Recursos</link>.
    </para>
    <para>
     Se <varname>$_SESSION</varname> (ou <varname>$HTTP_SESSION_VARS</varname>
-    em PHP 4.0.6 e anteriores) for utilizado, atribua valores para <varname>$_SESSION</varname>. Por exemplo: $_SESSION['var'] = 'ABC';
+    para PHP 4.0.6 e anteriores) for utilizado, atribua valores para
+    <varname>$_SESSION</varname>. Por exemplo: $_SESSION['var'] = 'ABC';
    </para>
   </note>
  </refsect1>

--- a/pt_BR/reference/session/functions/session-save-path.xml
+++ b/pt_BR/reference/session/functions/session-save-path.xml
@@ -1,38 +1,70 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: fernandoc Status: ready -->
-<!-- CREDITS: surfmax -->
-<!-- splitted from ./en/functions/session.xml, last change in rev 1.2 -->
-  <refentry xml:id="function.session-save-path" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>session_save_path</refname>
-    <refpurpose>Obtém e/ou define o save path da sessão atual</refpurpose>
-   </refnamediv>
-   <refsect1>
-    <title>Descrição</title>
-     <methodsynopsis>
-      <type>string</type><methodname>session_save_path</methodname>
-      <methodparam choice="opt"><type>string</type><parameter>path</parameter></methodparam>
-     </methodsynopsis>
-    <para>
-     <function>session_save_path</function> retorna o path do diretório atual
-     usado para salvar os dados de sessão. Se <parameter>path</parameter>
-     está especificado, o path para aqueles dados que estão salvo será mudado.
-     <function>session_save_path</function> precisa ser usada antes de
-     <function>session_start</function> para este uso.
-     <note>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 297028 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-save-path">
+ <refnamediv>
+  <refname>session_save_path</refname>
+  <refpurpose>Obtém e/ou define o caminho para armazenamento da sessão atual</refpurpose>
+ </refnamediv>
+ 
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>session_save_path</methodname>
+   <methodparam choice="opt"><type>string</type><parameter>path</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>session_save_path</function> retorna o caminho do diretório
+   atual utilizado para salvar os dados de sessão.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>path</parameter></term>
+     <listitem>
       <para>
-       Em alguns sistemas operacionais, você pode querer especificar um path em um
-       arquivo de sistema que cuida de muitos arquivos pequenos 
-       com eficiência. Por exemplo, em Linux, reiserfs pode oferecer
-       uma performance melhor do que ext2fs.
+       Caminho dos dados de sessão. Se informado, o caminho onde os dados são salvos será
+       alterado. <function>session_save_path</function> precisa ser chamada
+       antes de <function>session_start</function> para isto.
       </para>
-     </note>
-    </para>
-    <para>
-     Veja também a diretiva de configuração <link linkend="ini.session.save-path">session.save_path</link>.
-    </para>
-   </refsect1>
-  </refentry>
+      <para>
+       <note>
+        <para>
+         Em alguns sistemas operacionais, talvez você queira especificar um caminho em um
+         sistema de arquivos (filesystem) que possa manuzear grande quantidade de pequenos arquivos eficientemente. Por exemplo,
+         no Linux, reiserfs pode ter performance melhor do que ext2fs.
+        </para>
+       </note>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retorna o caminho atual do diretório usado para o armazenamento de dados.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member>
+     <link linkend="ini.session.save-path">session.save_path</link>
+     (diretiva de configuração)
+    </member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/pt_BR/reference/session/functions/session-set-cookie-params.xml
+++ b/pt_BR/reference/session/functions/session-set-cookie-params.xml
@@ -1,45 +1,144 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
-<refentry xml:id="function.session-set-cookie-params" xmlns="http://docbook.org/ns/docbook">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 334592 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-set-cookie-params">
  <refnamediv>
   <refname>session_set_cookie_params</refname>
-  <refpurpose>
-   Define os parâmetros do cookie de sessão
-  </refpurpose>
+  <refpurpose>Define os parâmetros do cookie de sessão</refpurpose>
  </refnamediv>
- <refsect1>
-  <title>Descrição</title>
+
+ <refsect1 role="description">
+  &reftitle.description;
   <methodsynopsis>
    <type>void</type><methodname>session_set_cookie_params</methodname>
    <methodparam><type>int</type><parameter>lifetime</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>path</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>domain</parameter></methodparam>
-   <methodparam choice="opt"><type>bool</type><parameter>secure</parameter></methodparam>
-   <methodparam choice="opt"><type>bool</type><parameter>httponly</parameter></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>secure</parameter><initializer>false</initializer></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>httponly</parameter><initializer>false</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Define parâmetros dos cookies como no arquivo &php.ini; file. O efeito desta
-   função é apenas pela duração do script. Então, então você precisa 
-   chamar <function>session_set_cookie_params</function> para cada requisição e antes
-   que <function>session_start</function> seja chamada. 
+   Define parâmetros dos cookies configurados no arquivo &php.ini;. O efeito desta
+   função é apenas pela duração do script. Então, você precisa
+   chamar <function>session_set_cookie_params</function> para cada requisição e
+   antes que <function>session_start</function> seja chamada.
   </para>
-  <note>
-   <para>
-     O parâmetro <parameter>secure</parameter> foi adicionado no PHP
-     4.0.4, enquanto o parâmetro <parameter>httponly</parameter>
-     foi adicionado no PHP 5.2.0.
-   </para>
-  </note>
   <para>
-   Veja também as diretivas de configuração
-   <link linkend="ini.session.cookie-lifetime">session.cookie_lifetime</link>,
-   <link linkend="ini.session.cookie-path">session.cookie_path</link>,
-   <link linkend="ini.session.cookie-domain">session.cookie_domain</link>,
-   <link linkend="ini.session.cookie-secure">session.cookie_secure</link>,
-   <link linkend="ini.session.cookie-httponly">session.cookie_httponly</link> e
-   <function>session_get_cookie_params</function>.
+   Esta função atualiza os valores em tempo de execução correspondentes às configurações INI
+   que podem ser obetidos com <function>ini_get</function>.
   </para>
  </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>lifetime</parameter></term>
+     <listitem>
+      <para>
+       <link linkend="ini.session.cookie-lifetime">Tempo de vida</link> do
+       cookie de sessão, definido em segundos.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>path</parameter></term>
+     <listitem>
+      <para>
+       <link linkend="ini.session.cookie-path">Caminho</link> no domínio onde
+       o cookie vai funcionar. Use uma única barra ('/') para que funcione em todos os caminhos do
+       domínio.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>domain</parameter></term>
+     <listitem>
+      <para>
+       <link linkend="ini.session.cookie-domain">Domínio</link> do cookie, por
+       exemplo 'www.php.net'. Para tornar os cookies visíveis em todos os subdomínios,
+       o domínio deve ser prefixado com um ponto, como '.php.net'.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>secure</parameter></term>
+     <listitem>
+      <para>
+       Se &true;, o cookie só será enviado em conexões
+       <link linkend="ini.session.cookie-secure">seguras</link>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>httponly</parameter></term>
+     <listitem>
+      <para>
+       Se &true;, então o PHP tentará enviar a flag
+       <link linkend="ini.session.cookie-httponly">httponly</link>
+       ao definir o cookie de sessão.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>5.2.0</entry>
+       <entry>
+        O parâmetro <parameter>httponly</parameter> foi adicionado.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member>
+     <link linkend="ini.session.cookie-lifetime">session.cookie_lifetime</link>
+    </member>
+    <member>
+     <link linkend="ini.session.cookie-path">session.cookie_path</link>
+    </member>
+    <member>
+     <link linkend="ini.session.cookie-domain">session.cookie_domain</link>
+    </member>
+    <member>
+     <link linkend="ini.session.cookie-secure">session.cookie_secure</link>
+    </member>
+    <member>
+     <link linkend="ini.session.cookie-httponly">session.cookie_httponly</link>
+    </member>
+    <member><function>session_get_cookie_params</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/pt_BR/reference/session/functions/session-set-save-handler.xml
+++ b/pt_BR/reference/session/functions/session-set-save-handler.xml
@@ -1,145 +1,399 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: fernandoc Status: ready -->
-<!-- CREDITS: surfmax -->
-<!-- splitted from ./en/functions/session.xml, last change in rev 1.23 -->
-  <refentry xml:id="function.session-set-save-handler" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>session_set_save_handler</refname>
-    <refpurpose>
-     Define a sequência de funções de armazenamento 
-    </refpurpose>
-   </refnamediv>
-   <refsect1>
-    <title>Descrição</title>
-     <methodsynopsis>
-      <type>bool</type><methodname>session_set_save_handler</methodname>
-      <methodparam><type>callback</type><parameter>open</parameter></methodparam>
-      <methodparam><type>callback</type><parameter>close</parameter></methodparam>
-      <methodparam><type>callback</type><parameter>read</parameter></methodparam>
-      <methodparam><type>callback</type><parameter>write</parameter></methodparam>
-      <methodparam><type>callback</type><parameter>destroy</parameter></methodparam>
-      <methodparam><type>callback</type><parameter>gc</parameter></methodparam>
-    </methodsynopsis>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 334814 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-set-save-handler">
+ <refnamediv>
+  <refname>session_set_save_handler</refname>
+  <refpurpose>Define funções de armazenamento de sessão</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>session_set_save_handler</methodname>
+   <methodparam><type>callable</type><parameter>open</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>close</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>read</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>write</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>destroy</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>gc</parameter></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>create_sid</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   A partir do PHP 5.4 é possível registrar o seguinte protótipo:
+  </para>
+  <methodsynopsis>
+   <type>bool</type><methodname>session_set_save_handler</methodname>
+   <methodparam><type>SessionHandlerInterface</type><parameter>sessionhandler</parameter></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>register_shutdown</parameter><initializer>true</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>session_set_save_handler</function> define as funções de
+   armazenamento de sessão que serão usadas par guardar e
+   buscar dados associados com uma sessão.  Ela é mais útil
+   quando um método de armazenamento diferente do disponibilizado pelas sessões do PHP
+   é preferido. i.e. Armazenar os dados de sessão em um banco de dados.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   Esta função tem dois protótipos.
+   <variablelist>
+    <varlistentry>
+     <term><parameter>sessionhandler</parameter></term>
+     <listitem>
+      <para>
+       Uma instância de uma classe implementando
+       <interfacename>SessionHandlerInterface</interfacename>, como
+       <classname>SessionHandler</classname>, para registrá-la como manipulador
+       de sessão. Apenas a partir do PHP 5.4.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>register_shutdown</parameter></term>
+     <listitem>
+      <para>
+       Registra <function>session_write_close</function> como uma função
+       <function>register_shutdown_function</function>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+
+   or
+
+   <variablelist>
+    <varlistentry>
+     <term><parameter>open(string $savePath, string $sessionName)</parameter></term>
+     <listitem>
+      <para>
+       O callback open trabalha como um construtor em classes e é
+       executado quando a sessão está sendo aberta.  É a primeira função de
+       callback executada quando a sessão é iniciada automaticamente ou
+       manualmente com <function>session_start</function>.
+       O valor de retorno é &true; para sucesso, &false; para falha.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>close()</parameter></term>
+     <listitem>
+      <para>
+       O callback close trabalha como um destrutor em classes e é
+       executado depois que o callback write for chamado. Ele também é invocado quando a função
+       <function>session_write_close</function> é chamada.
+       O valor de retorno é &true; para sucesso, &false; para falha.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>read(string $sessionId)</parameter></term>
+     <listitem>
+      <para>
+       O callback <parameter>read</parameter> deve sempre retornar uma sessão codificada (serializada) no formato
+       string ou uma string vazia se não há dados para leitura.
+      </para>
+      <para>
+       Este callback é chamado internamente pelo PHP quando a sessão inicia ou
+       quando a função <function>session_start</function> é chamada.  Antes que este callback seja invocado,
+       o PHP invocará o callback <parameter>open</parameter>.
+      </para>
+      <para>
+       O valor que este callback retorna deve estar exatamente no mesmo formato de serialização que originalmente foi
+       passado para armazenamento ao callback <parameter>write</parameter>.  O valor retornado será
+       deserializado automaticamente pelo PHP e usado para preencher a super global <varname>$_SESSION</varname>.
+       Mesmo que os dados pareçam similares ao de <function>serialize</function>, note que é um formato diferente,
+       especificado na configuração INI <link linkend="ini.session.serialize-handler">session.serialize_handler</link>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>write(string $sessionId, string $data)</parameter></term>
+     <listitem>
+      <para>
+       O callback <parameter>write</parameter> é chamado quando a sessão precisa ser salva e fechada. Este
+       callback recebe o ID da sessão atual e uma versão serializada da super global <varname>$_SESSION</varname>. O método de
+       serialização usado internamente pelo PHP é definido configuração ini <link linkend="ini.session.serialize-handler">session.serialize_handler</link>.
+      </para>
+      <para>
+       Os dados de sessão serializados passado para este callback devem ser armazenados junto com o ID de sessão passado. Ao buscar
+       estes dados, o callback <parameter>read</parameter> deve retornar o valor exato que foi passado originalmente para
+       o callback <parameter>write</parameter>.
+      </para>
+      <para>
+       Este callback é invocado quando o PHP é encerrado ou explicitamente quando a função <function>session_write_close</function>
+       é chamada.  Note que depois de executar esta função, o PHP executará internamente o callback <parameter>close</parameter>.
+       <note>
+        <para>
+         O manipulador "write" não é executado enquanto o fluxo de saída não for
+         encerrado.  Portanto, saída de comandos de debug no manipulador "write"
+         nunca serão vistas pelo browser.  Se a saída de debug é
+         necessária, é recomendado que ela seja escrita
+         em arquivo.
+        </para>
+       </note>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>destroy($sessionId)</parameter></term>
+     <listitem>
+      <para>
+       Este callback é executado quando uma sessão é destruída com <function>session_destroy</function> ou com
+       <function>session_regenerate_id</function> com o parâmetro de destruição definido como &true;.
+       O valor de retorno deve ser &true; para sucesso, &false; para falha.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>gc($lifetime)</parameter></term>
+     <listitem>
+      <para>
+       O callback de limpeza (gc) é invocado pelo PHP, internamente e periodicamente, para apagar
+       dados de sessão antiga.  A frequência é controlada por
+       <link linkend="ini.session.gc-probability">session.gc_probability</link> e <link linkend="ini.session.gc-divisor">session.gc_divisor</link>.
+       O valor do parâmetro que é passado para este callback pode ser definido em <link linkend="ini.session.gc-maxlifetime">session.gc_maxlifetime</link>.
+       O valor de retorno deve ser &true; para sucesso, &false; para falha.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>create_sid()</parameter></term>
+     <listitem>
+      <para>
+       Este callback é executado quando um novo ID de sessão é necessário. Nenhum
+       parâmetro é necessário e o valor de retorno deve ser uma string que
+       seja um ID de sessão válido para seu manipulador.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>
+     Manipulador de sessão personalizado: veja o código completo na sinópse de <classname>SessionHandlerInterface</classname>.
+    </title>
     <para>
-     <function>session_set_save_handler</function> define a sequência 
-     de funções de armazenamento  que é usada para guardar e devolver
-     dados associados à sessão. Esta é mais usual quando um
-     quando um método de armazenamento, a não ser que aquele oferecido por 
-     sessões do PHP seja preferível.  i.e. Guardar dados de sessão em um
-     banco de dados local.
-     &return.success;
+     O código a seguir é para o PHP 5.4.0 ou superior.  Aqui é demonstrado apenas a execução, o código completo pode ser
+     visto na sinópse de <classname>SessionHandlerInterface</classname> no link acima.
     </para>
-    <note>
-     <para>
-      A função "write" handler não é executada até depois que o fluxo de saída
-      esteja fechado. Assim, a saída de instruções debugging na função
-      "write" handler poderá nunca ser vista pelo navegador. Se a saída 
-      debugging é necessária, ao invés disso é sugerido que a saída debug 
-      seja escrita para um arquivo.
-     </para>
-    </note>
     <para>
-     O seguinte exemplo oferece um aramzenamento de sessão baseado em
-      arquivos similar a sessões de PHP padrões save handler
-     <parameter>files</parameter>.  Este exemplo poderia facilmente ser
-     extendido para outras bases de dados usando seu gerente de banco de dados favorito suportado pelo PHP.
+     Note que é usado orientação à objetos com <function>session_set_save_handler</function> e
+     a função de encerramento (register_shutdown) é registrada usando sua respectiva flag.  Isto é
+     aconselhável ao registrar objetos como manipuladores de gravação de sessão.
     </para>
-    <para>
-     A função "Read" deve retornar um valor string sempre que fizer o save handler
-      trabalhar como o esperado. Retorna uma string vazia se não existe dados para
-     ler. Retorna valores de outros handlers que estejam convertidos para expressões booleanas. TRUE em sucesso, FALSE em falha.
-    </para>
-    <warning>
-     <para>
-      Os manipuladores Write e Close são chamados após os objetos serem destruídos desde o PHP
-      5.0.5. Então destruidores podem usar sessões mas o manipulador de sessão não pode usar
-      objetos. Em versões anteriores, eles eram chamados na ordem oposta. è
-      possível usar <function>session_write_close</function> a partir do
-      destruidor para resolver este problema da galinha e do ovo.
-     </para>
-    </warning>
-    <para>
-     <example>
-      <title>
-       <function>session_set_save_handler</function> exemplo
-      </title>
-      <programlisting role="php">
+    <programlisting role="php">
 <![CDATA[
 <?php
-function open($save_path, $session_name) 
+class MySessionHandler implements SessionHandlerInterface
 {
-  global $sess_save_path, $sess_session_name;
-       
-  $sess_save_path = $save_path;
-  $sess_session_name = $session_name;
-  return(true);
+    // implementa a interface aqui
 }
 
-function close() 
-{
-  return(true);
-}
-
-function read($id) 
-{
-  global $sess_save_path, $sess_session_name;
-
-  $sess_file = "$sess_save_path/sess_$id";
-  if ($fp = @fopen($sess_file, "r")) {
-    $sess_data = fread($fp, filesize($sess_file));
-    return($sess_data);
-  } else {
-    return(""); // Must return "" here.
-  }
-
-}
-
-function write($id, $sess_data) 
-{
-  global $sess_save_path, $sess_session_name;
-
-  $sess_file = "$sess_save_path/sess_$id";
-  if ($fp = @fopen($sess_file, "w")) {
-    return(fwrite($fp, $sess_data));
-  } else {
-    return(false);
-  }
-
-}
-
-function destroy($id) 
-{
-  global $sess_save_path, $sess_session_name;
-       
-  $sess_file = "$sess_save_path/sess_$id";
-  return(@unlink($sess_file));
-}
-
-/*********************************************
- * WARNING - You will need to implement some *
- * sort of garbage collection routine here.  *
- *********************************************/
-function gc($maxlifetime) 
-{
-  return true;
-}
-
-session_set_save_handler("open", "close", "read", "write", "destroy", "gc");
-
+$handler = new MySessionHandler();
+session_set_save_handler($handler, true);
 session_start();
 
-// proceed to use sessions normally
-
-?>
+// proceder para definir e recuperar os valores pela chave de $_SESSION
 ]]>
-      </programlisting>
-     </example>
+    </programlisting>
+   </example>
+   <example>
+    <title>Manipuladores personalizados de gravação de sessão usando objetos</title>
+    <para>
+     O código a seguir é para versões do PHP anteriores à 5.4.0.
     </para>
     <para>
-     Veja também a diretiva de configuração <link linkend="ini.session.save-handler">session.save_handler</link>.
+     O exemplo a seguir apresenta um armazenamento de sessão baseada em arquivos semelhante aos
+     manipuladores de gravação de sessão padrões do PHP <parameter>files</parameter>.  Este
+     exemplo poderia ser facilmente estendido para cobrir armazenamento em banco de dados usando sua
+     engine de banco de dados favorita e que seja suportada pelo PHP.
     </para>
-   </refsect1>
-  </refentry>
+    <para>
+     Note que foi registrada a função <function>session_write_close</function>
+     usando <function>register_shutdown_function</function> em versões do PHP anteriores à 5.4.0.
+     Isto é aconselhável ao registrar objetos como manipuladores de gravação de sessão em versões anteriores
+     à 5.4.0.
+    </para>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class FileSessionHandler
+{
+    private $savePath;
+
+    function open($savePath, $sessionName)
+    {
+        $this->savePath = $savePath;
+        if (!is_dir($this->savePath)) {
+            mkdir($this->savePath, 0777);
+        }
+
+        return true;
+    }
+
+    function close()
+    {
+        return true;
+    }
+
+    function read($id)
+    {
+        return (string)@file_get_contents("$this->savePath/sess_$id");
+    }
+
+    function write($id, $data)
+    {
+        return file_put_contents("$this->savePath/sess_$id", $data) === false ? false : true;
+    }
+
+    function destroy($id)
+    {
+        $file = "$this->savePath/sess_$id";
+        if (file_exists($file)) {
+            unlink($file);
+        }
+
+        return true;
+    }
+
+    function gc($maxlifetime)
+    {
+        foreach (glob("$this->savePath/sess_*") as $file) {
+            if (filemtime($file) + $maxlifetime < time() && file_exists($file)) {
+                unlink($file);
+            }
+        }
+
+        return true;
+    }
+}
+
+$handler = new FileSessionHandler();
+session_set_save_handler(
+    array($handler, 'open'),
+    array($handler, 'close'),
+    array($handler, 'read'),
+    array($handler, 'write'),
+    array($handler, 'destroy'),
+    array($handler, 'gc')
+    );
+
+// a linha a seguir evita comportamentos não esperados ao usar objetos como manipuladores de gravação
+register_shutdown_function('session_write_close');
+
+session_start();
+// proceder para definir e recuperar valores pela chave de $_SESSION
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <warning>
+   <para>
+    Ao utilizar objetos como manipuladores de gravação de sessão, é importante registrar a função de
+    finalização no PHP para evitar efeitos colaterais não esperados devido à forma como o
+    PHP destrói objetos internamente em seu encerramento e que pode impedir que as funções
+    <parameter>write</parameter> e <parameter>close</parameter> sejam executadas.
+    Normalmente, <parameter>'session_write_close'</parameter> deve ser registrada usando a função
+    <function>register_shutdown_function</function>.
+   </para>
+   <para>
+    A partir do PHP 5.4.0 pode ser usado <function>session_register_shutdown</function> ou
+    simplesmente a flag 'register shutdown' ao invocar
+    <function>session_set_save_handler</function> usando o método orientado à objetos e passando uma
+    instância que implemente <classname>SessionHandlerInterface</classname>.
+   </para>
+  </warning>
+  <warning>
+   <para>
+    A partir do PHP 5.0.5 os manipuladores <parameter>write</parameter> e
+    <parameter>close</parameter> são executados depois da destruição do
+    objeto e portanto não podem usar objetos ou lançar exceções.
+    Não é possível capturar nem
+    exibir o rastro (trace) de exceções e a execução simplesmente será interrompida de forma inesperada.
+    Ainda assim, os destrutores do objeto podem usar sessões.
+   </para>
+   <para>
+    É possível chamar <function>session_write_close</function> do
+    destrutor para resolver este problema de 'o ovo e a galinha' mas a forma mais confiável é
+    registrar a função de finalização como descrito acima.
+   </para>
+  </warning>
+  <warning>
+   <para>
+    O diretório de trabalho atual é alterado com algumas SAPIs (Server API) se a sessão for
+    fechada na finalização do script. É possível fechar a sessão de forma
+    antecipada com <function>session_write_close</function>.
+   </para>
+  </warning>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>5.5.1</entry>
+      <entry>
+       Adicionado o parâmetro opcional <parameter>create_sid</parameter>.
+      </entry>
+     </row>
+     <row>
+      <entry>5.4.0</entry>
+      <entry>
+       Adicionado <interfacename>SessionHandlerInterface</interfacename> para implementação de manipuladores de sessão e
+       <classname>SessionHandler</classname> para expor manipuladores de sessão internas do PHP.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member>
+     <link linkend="ini.session.save-handler">session.save_handler</link>
+     (diretiva de configuração)
+    </member>
+    <member>
+     <link linkend="ini.session.serialize-handler">session.serialize_handler</link>
+     (diretiva de configuração)
+    </member>
+    <member>A <function>register_shutdown_function</function></member>
+    <member>A <function>session_register_shutdown</function> para PHP 5.4.0+</member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/pt_BR/reference/session/functions/session-start.xml
+++ b/pt_BR/reference/session/functions/session-start.xml
@@ -1,44 +1,137 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: fernandoc Status: ready -->
-<!-- CREDITS: surfmax -->
-<!-- splitted from ./en/functions/session.xml, last change in rev 1.2 -->
-  <refentry xml:id="function.session-start" xmlns="http://docbook.org/ns/docbook">
-   <refnamediv>
-    <refname>session_start</refname>
-    <refpurpose>Inicia dados de sessão</refpurpose>
-   </refnamediv>
-   <refsect1>
-    <title>Descrição</title>
-     <methodsynopsis>
-      <type>bool</type><methodname>session_start</methodname>
-      <void/>
-     </methodsynopsis>
-    <simpara>
-     <function>session_start</function> cria uma sessão (ou resume
-      a sessão atual baseada numa id de sessão sendo passada via 
-      uma variável GET ou um cookie).
-    </simpara>
-    <simpara>
-     Esta função sempre retorna &true;.
-    </simpara>
-    <note>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 337868 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-start">
+ <refnamediv>
+  <refname>session_start</refname>
+  <refpurpose>Inicia uma nova sessão ou resume uma sessão existente</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>session_start</methodname>
+   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>[]</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>session_start</function> cria uma sessão ou resume a
+   sessão atual baseado em um id de sessão passado via GET ou POST,
+   ou passado via cookie.
+  </para>
+  <para>
+   Quando <function>session_start</function> é chamada ou quando uma sessão inicia automaticamente,
+   o PHP chamará os manipuladores open e read.  Eles serão manipuladores de gravação internos (built-in)
+   fornecidos por padrão ou por extensões do PHP (como SQLite ou Memcached); ou podem ser
+   manipuladores personalizados definidos por <function>session_set_save_handler</function>.
+   O callback read recuperará qualquer informação de sessão existente (armazenada em um formato serializado especial)
+   e será deserializado e usado para preencher automaticamente a super global $_SESSION quando o
+   callback read retornar de volta os dados salvos em sessão para o manipulador de sessão do PHP.
+  </para>
+  <para>
+   Para utilizar uma sessão com nome, execute
+   <function>session_name</function> antes de executar
+   <function>session_start</function>.
+  </para>
+  <para>
+   Quando <link linkend="ini.session.use-trans-sid">session.use_trans_sid</link>
+   está habilitada, a função <function>session_start</function>
+   registrará um manipulador de saída interno para a reescrita da URL.
+  </para>
+  <para>
+   Se um usuário usar <literal>ob_gzhandler</literal> ou similar com
+   <function>ob_start</function>, a ordem da função é importante para
+   saída/output adequado.  Por exemplo,
+   <literal>ob_gzhandler</literal> deve ser registrado antes de iniciar a sessão.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
      <para>
-      Se você está usando sessões baseadas em cookie, você deve chamar
-      <function>session_start</function> antes de qualquer coisa ser exibida
-      para o navegador.
+      Se informado, este é um array associativo de opções que vão sobrepor
+      os que estiverem configurados nas
+      <link linkend="session.configuration">diretivas de configuração de sessão</link>.
+      As chaves não devem incluir o prefixo da <literal>session</literal>.
      </para>
-    </note>
-    <para>
-     <example>
-      <title>Um exemplo de seção: <filename>page1.php</filename></title>
-      <programlisting role="php">
+     <para>
+      Além do conjunto de diretivas de configuração comum, a opção
+      <literal>read_and_close</literal> pode ser informada. Se definida como
+      &true;, fará com que a sessão seja fechada imediatamente depois de
+      ser lida, evitando o bloqueio desnecessário caso os dados da sessão
+      não sejam alterados.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Esta função retorna &true; se uma sessão foi iniciada com sucesso,
+   caso contrário &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>7.0.0</entry>
+       <entry>
+        O parâmetro <parameter>options</parameter> foi adicionado.
+       </entry>
+      </row>
+      <row>
+       <entry>5.3.0</entry>
+       <entry>
+        Se uma sessão falhar para iniciar, então é retornado &false;.
+        Anteriormente, &true; era retornado.
+       </entry>
+      </row>
+      <row>
+       <entry>4.3.3</entry>
+       <entry>
+        A partir do PHP 4.3.3, chamar <function>session_start</function>
+        depois da sessão já ter iniciada resultará em um
+        erro de level <constant>E_NOTICE</constant>.  E a
+        a segunda chamada para iniciar a sessão simplesmente será ignorada.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <refsect2>
+   <title>Um exemplo básico de sessão</title>
+
+   <para>
+    <example>
+     <title><filename>page1.php</filename></title>
+     <programlisting role="php">
 <![CDATA[
 <?php
 // page1.php
 
 session_start();
 
-echo 'Bem vindo a pagina #1';
+echo 'Bem vindo à página #1';
 
 $_SESSION['favcolor'] = 'green';
 $_SESSION['animal']   = 'cat';
@@ -51,74 +144,114 @@ echo '<br /><a href="page2.php">page 2</a>';
 echo '<br /><a href="page2.php?' . SID . '">page 2</a>';
 ?>
 ]]>
-      </programlisting>
-     </example>
-    </para>
-    <para>
-     Após ver <filename>page1.php</filename>, a segunda pagina
-     <filename>page2.php</filename> irá magicamente conter os dados da seção.
-     Leia <link linkend="ref.session">Uso de seções</link>
-     para informações sobre <link linkend="session.idpassing">propagando
-     ids de seções</link> já que, por exemplo, explica tudo sobre a constante
-     <constant>SID</constant>.
-    </para>
-    <para>
-     <example>
-      <title>Um exemplo de seção: <filename>page2.php</filename></title>
-      <programlisting role="php">
+     </programlisting>
+    </example>
+   </para>
+   <para>
+    Após acessar <filename>page1.php</filename>, a segunda página
+    <filename>page2.php</filename> magicamente terá os dados da
+    seção.  Leia <link linkend="ref.session">funções para sessão</link>
+    para informações sobre <link linkend="session.idpassing">propagação de
+    ids de sessão</link> já que, por exemplo, explica tudo sobre a constante
+    <constant>SID</constant>.
+   </para>
+   <para>
+    <example>
+     <title><filename>page2.php</filename></title>
+     <programlisting role="php">
 <![CDATA[
 <?php
 // page2.php
 
 session_start();
 
-echo 'Bem vindo a pagina #2<br />';
+echo 'Bem vindo à página #2<br />';
 
 echo $_SESSION['favcolor']; // green
 echo $_SESSION['animal'];   // cat
 echo date('Y m d H:i:s', $_SESSION['time']);
 
-// Você pode querer usar o SID aqui, como fissemos em page1.php
+// Você pode querer usar o SID aqui, como fizemos em page1.php
 echo '<br /><a href="page1.php">page 1</a>';
 ?>
 ]]>
-      </programlisting>
-     </example>
-    </para>
-    <simpara>
-     Se você quiser usar uma seção com nomes, você deve usar
-     <function>session_name</function> antes de
-     <function>session_start</function>.
-    </simpara>
-    <simpara>
-     <function>session_start</function> irá registrar um handler de saída
-     interno para URL reescrevendo quando <literal>trans-sid</literal> está
-     habilitada. Se um usuário utiliza <literal>ob_gzhandler</literal> ou
-      <function>ob_start</function>, a ordem do handler de exibição
-     é importante para a exibição apropriada. Por exemplo, usuário
-     deve registrar <literal>ob_gzhandler</literal> antes da sessão começar.
-    </simpara>
-    <note>
-     <simpara>
-      Uso de <link linkend="ini.zlib.output-compression">zlib.output_compression</link>  é mais
-      recomendado do que <literal>ob_gzhandler</literal>
-     </simpara>
-    </note>
-    <note>
-     <para>
-      Apartir do PHP 4.3.3, usar <function>session_start</function> quando a seção já tiver
-      sido iniciada irá resultar em um erro de nível.
-      <constant>E_NOTICE</constant>.  Também, o segundo início de seção será simplesmente ignorado.
-     </para>
-    </note>
-    <para>
-     Veja também
-     <link linkend="reserved.variables.session">$_SESSION</link>,
-     <link linkend="ini.session.auto-start">session.auto_start</link>, e
-     <function>session_id</function>.
-    </para>
-   </refsect1>
-  </refentry>
+     </programlisting>
+    </example>
+   </para>
+  </refsect2>
+  <refsect2>
+   <title>Fornecendo configurações para <function>session_start</function></title>
+
+   <example>
+    <title>Sobrepondo o tempo de duração de cookie</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// Envia o cookie persistente que dura um dia
+session_start([
+    'cookie_lifetime' => 86400,
+]);
+?>
+]]>
+    </programlisting>
+   </example>
+
+   <example>
+    <title>Lendo e fechando a sessão</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// Se não houver necessidade de alterar nada na
+// sessão, pode-se apenas lê-la e já fechá-la para avitar
+// que o arquivo de sessão seja travado e então bloqueie outras páginas
+session_start([
+    'cookie_lifetime' => 86400,
+    'read_and_close'  => true,
+]);
+]]>
+    </programlisting>
+   </example>
+  </refsect2>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    Para usar sessões baseadas em cookies, <function>session_start</function>
+    deve ser chamada antes de enviar qualquer saída (output) para o browser.
+   </para>
+  </note>
+  <note>
+   <para>
+    O uso de <link linkend="ini.zlib.output-compression">zlib.output_compression</link>
+    é recomendado ao invés de <function>ob_gzhandler</function>
+   </para>
+  </note>
+  <note>
+   <para>
+    Esta função envia vários cabeçalhos HTTP dependendo da
+    configuração. Veja <function>session_cache_limiter</function> para
+    personalizar estes cabeçalhos.
+   </para>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><varname>$_SESSION</varname></member>
+    <member>
+     <link linkend="ini.session.auto-start">session.auto_start</link>
+     (diretiva de configuração)
+    </member>
+    <member><function>session_id</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/pt_BR/reference/session/functions/session-unregister.xml
+++ b/pt_BR/reference/session/functions/session-unregister.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: n/a Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
-<refentry xml:id="function.session-unregister" xmlns="http://docbook.org/ns/docbook">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 323674 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-unregister">
  <refnamediv>
   <refname>session_unregister</refname>
   <refpurpose>Desregistra uma variável global da sessão atual</refpurpose>
@@ -16,6 +16,7 @@
    <function>session_unregister</function> desregistra a variável global 
    chamada <parameter>name</parameter> da sessão atual.
   </para>
+  &warn.deprecated.function-5-3-0.removed-5-4-0;
  </refsect1>
 
  <refsect1 role="parameters">
@@ -46,17 +47,17 @@
   <note>
    <para>
     Se <varname>$_SESSION</varname> (ou <varname>$HTTP_SESSION_VARS</varname> 
-    para PHP 4.0.6 ou inferior) é usada, use <function>unset</function> para 
+    para PHP 4.0.6 ou inferior) for usada, use <function>unset</function> para 
     desregistrar uma variável de sessão. Não use <function>unset</function> 
-    na própria <varname>$_SESSION</varname> já que irá desabilitar a função 
-    especial de superglobal da <varname>$_SESSION</varname>.
+    na própria <varname>$_SESSION</varname> já que desabilitará a função 
+    especial da super global <varname>$_SESSION</varname>.
    </para>
   </note>
   <caution>
    <para>
-    Esta função não elimina a variável global correspondente por
-    <parameter>name</parameter>, ela apenas evita que a variável faça parte
-    da sessão. Você deve chamar <function>unset</function>
+    Esta função não elimina a variável global correspondente de
+    <parameter>name</parameter>, ela apenas evita que a variável faça
+    parte da sessão. Você deve chamar <function>unset</function>
     para eliminar a variável global correspondente.
    </para>
   </caution>

--- a/pt_BR/reference/session/functions/session-unset.xml
+++ b/pt_BR/reference/session/functions/session-unset.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 297028 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
-<refentry xml:id="function.session-unset" xmlns="http://docbook.org/ns/docbook">
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-unset">
  <refnamediv>
   <refname>session_unset</refname>
   <refpurpose>Libera todas as variáveis de sessão</refpurpose>
@@ -13,8 +13,8 @@
    <void/>
   </methodsynopsis>
   <para>
-   A função <function>session_unset</function> libera todas as variáveis da sessão
-   atualmente registradas.
+   A função <function>session_unset</function> libera todas as variáveis atualmente
+   registradas na sessão.
   </para>
  </refsect1>
 
@@ -29,17 +29,17 @@
   &reftitle.notes;
   <note>
    <para>
-    Se <varname>$_SESSION</varname> (ou <varname>$HTTP_SESSION_VARS</varname> para 
-    PHP 4.0.6 ou inferior) é usada, utilize <function>unset</function>
-    para desregistrar a variável da sessão. i.e. 
-    <literal>unset($_SESSION['varname']);</literal>.
+    Se <varname>$_SESSION</varname> (ou <varname>$HTTP_SESSION_VARS</varname>
+    para PHP 4.0.6 ou inferior) for usada, use <function>unset</function> para
+    desregistrar a variável da sessão, isto é,
+    <literal>unset ($_SESSION['varname']);</literal>.
    </para>
   </note>
   <caution>
    <para>
-    NÃO elimina completamente <varname>$_SESSION</varname> com
-    <literal>unset($_SESSION)</literal> enquanto esta desabilitará o registro de 
-    variáveis de sessão pela <varname>$_SESSION</varname> superglobal.
+    NÃO elimine completamente <varname>$_SESSION</varname> com
+    <literal>unset($_SESSION)</literal> já que isto desabilitará o registro de
+    variáveis de sessão através da super global <varname>$_SESSION</varname>.
    </para>
   </caution>
  </refsect1>

--- a/pt_BR/reference/session/functions/session-write-close.xml
+++ b/pt_BR/reference/session/functions/session-write-close.xml
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- EN-Revision: 297028 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
-<refentry xml:id="function.session-write-close" xmlns="http://docbook.org/ns/docbook">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 323402 Maintainer: fernandoc Status: ready --><!-- CREDITS: surfmax -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-write-close">
  <refnamediv>
   <refname>session_write_close</refname>
-  <refpurpose>Escreve dados de sessão e termina a sessão</refpurpose>
+  <refpurpose>Guarda os dados de sessão e fecha a sessão</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">
@@ -13,17 +13,16 @@
    <void/>
   </methodsynopsis>
   <para>
-   Termina a sessão atual e guarda os dados.
+   Fecha a sessão atual e guarda os dados.
   </para>
   <para>
-   Os dados de sessão sã geralmente guardados depois que o script termina sem a 
-   necessidade de chamar <function>session_write_close</function>, mas como
-   dados de sessão são trancados para evitar escritas concorrentes, apenas um 
-   script pode operar em uma sessão de cada vez. Quando usando framesets
-   junto com sessões você irá experimentar os frames sendo lidos um a um devido
-   a esta trava. Você pode reduzir o tempo necessário para ler todos os frames 
-   terminando a sessão tão logo todas as mudanças das variáveis de sessão estejam
-   feitas.
+   Os dados de sessão geralmente são guardados depois que o script termina, sem a
+   necessidade de chamar <function>session_write_close</function>; mas como
+   dados de sessão são travados para evitar escritas concorrentes, apenas um
+   script pode operar em uma sessão por vez. Ao usar iframe/framesets junto com sessões,
+   os frames serão lidos um a um devido à esta trava. Pode-se
+   reduzir o tempo necessário para carregar todos os frames fechando a sessão o
+   mais cedo possível, assim que todas as alterações na variável de sessão tiverem sido feitas.
   </para>
  </refsect1>
 
@@ -31,6 +30,17 @@
   &reftitle.returnvalues;
   <para>
    &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member>
+     A <function>session_register_shutdown</function>
+    </member>
+   </simplelist>
   </para>
  </refsect1>
 


### PR DESCRIPTION
Alterações realizadas:

- Adicionada a tag de revisão nos arquivos que estavam sem;

- A tradução foi atualizada de acordo com a documentação original (EN);

- Melhoria em algumas frases que não sofreram alterações na documentação original (EN) mas estavam com erros de gramática, não faziam muito sentido ou a tradução estava confusa;