### PR TITLE
Correção de exemplo União de $a += $b:

### DIFF
--- a/pt_BR/language/operators.xml
+++ b/pt_BR/language/operators.xml
@@ -2058,32 +2058,32 @@ var_dump($a);
     Quando executado, o script produz uma saída assim:
     <screen role="php">
 <![CDATA[
-União de $a e $b:
-array(3) {
-  ["a"]=>
-  string(5) "maçã"
-  ["b"]=>
-  string(6) "banana"
-  ["c"]=>
-  string(6) "morango"
-}
-União de $b e $a:
-array(3) {
-  ["a"]=>
-  string(4) "pêra"
-  ["b"]=>
-  string(10) "framboesa"
-  ["c"]=>
-  string(6) "morango"
-}
-União de $a += $b:
+União de $a e $b: 
 array(3) {
   'a' =>
-  string(5) "maçã"
+  string(6) "maçã"
   'b' =>
   string(6) "banana"
   'c' =>
-  string(6) "framboesa"
+  string(7) "morango"
+}
+União de $b e $a: 
+array(3) {
+  'a' =>
+  string(5) "pêra"
+  'b' =>
+  string(9) "framboesa"
+  'c' =>
+  string(7) "morango"
+}
+União de $a += $b: 
+array(3) {
+  'a' =>
+  string(6) "maçã"
+  'b' =>
+  string(6) "banana"
+  'c' =>
+  string(7) "morango"
 }
 ]]>
     </screen>


### PR DESCRIPTION
Na tradução o exemplo `União de $a += $b:` estava incorreto, mostrando `framboesa` ao invés de `morango`. Rodei o código do exemplo e ele acabou corrigindo algumas outras coisas, como o tamanho das strings  e inconsistencias no output da saída que estão na versão original em inglês.