### PR TITLE
Correção de tradução muito rasa.

### DIFF
--- a/pt_BR/reference/array/functions/array-walk.xml
+++ b/pt_BR/reference/array/functions/array-walk.xml
@@ -53,10 +53,10 @@
        </para>
       </note>
       <para>
-       Usuários não podem modificar o próprio <parameter>array</parameter> na
-       função callback e.g. Adicionar/deletar elementos, apagar elementos, etc. Se
-       o array que <function>array_walk</function> é aplicado é
-       modificado, o comportamento desta função é indefinido, e imprevisível.
+        Apenas os valores de um <parameter>array</parameter> podem potencialmente ser alterados; sua estrutura
+        não pode ser alterada, por exemplo, o programador não pode adicionar, remover ou
+        reordenar elementos. Se o callback não respeitar esta regra, o comportamento desta
+        função é indefinido, e imprevisível.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
A tradução anterior não informava que não é possível modificar as chaves do array.