### PR TITLE
Update reference/errorfunc/ini pt_BR translation

### DIFF
--- a/pt_BR/reference/errorfunc/ini.xml
+++ b/pt_BR/reference/errorfunc/ini.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision: 325978 $ -->
+<!-- EN-Revision: 346421 Maintainer: none Status: ready --><!-- CREDITS: @mauriciofauth -->
 <section xml:id="errorfunc.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.runtime;
  &extension.runtime;
  <para>
   <table>
-   <title>Errors and Logging Configuration Options</title>
+   <title>Opções de Configuração de Erros e de Logs</title>
    <tgroup cols="4">
     <thead>
      <row>
@@ -44,25 +44,25 @@
      <entry><link linkend="ini.log-errors-max-len">log_errors_max_len</link></entry>
      <entry>"1024"</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry>Available since PHP 4.3.0.</entry>
+     <entry>Disponível a partir do PHP 4.3.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.ignore-repeated-errors">ignore_repeated_errors</link></entry>
      <entry>"0"</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry>Available since PHP 4.3.0.</entry>
+     <entry>Disponível a partir do PHP 4.3.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.ignore-repeated-source">ignore_repeated_source</link></entry>
      <entry>"0"</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry>Available since PHP 4.3.0.</entry>
+     <entry>Disponível a partir do PHP 4.3.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.report-memleaks">report_memleaks</link></entry>
      <entry>"1"</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry>Available since PHP 4.3.0.</entry>
+     <entry>Disponível a partir do PHP 4.3.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.track-errors">track_errors</link></entry>
@@ -80,25 +80,25 @@
      <entry><link linkend="ini.xmlrpc-errors">xmlrpc_errors</link></entry>
      <entry>"0"</entry>
      <entry>PHP_INI_SYSTEM</entry>
-     <entry>Available since PHP 4.1.0.</entry>
+     <entry>Disponível a partir do PHP 4.1.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.xmlrpc-error-number">xmlrpc_error_number</link></entry>
      <entry>"0"</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry>Available since PHP 4.1.0.</entry>
+     <entry>Disponível a partir do PHP 4.1.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.docref-root">docref_root</link></entry>
      <entry>""</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry>Available since PHP 4.3.0.</entry>
+     <entry>Disponível a partir do PHP 4.3.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.docref-ext">docref_ext</link></entry>
      <entry>""</entry>
      <entry>PHP_INI_ALL</entry>
-     <entry>Available since PHP 4.3.2.</entry>
+     <entry>Disponível a partir do PHP 4.3.2.</entry>
     </row>
     <row>
      <entry><link linkend="ini.error-prepend-string">error_prepend_string</link></entry>
@@ -118,6 +118,24 @@
      <entry>PHP_INI_ALL</entry>
      <entry></entry>
     </row>
+    <row>
+     <entry><link linkend="ini.syslog.facility">syslog.facility</link></entry>
+     <entry>"LOG_USER"</entry>
+     <entry>PHP_INI_SYSTEM</entry>
+     <entry>Disponível a partir do PHP 7.3.0.</entry>
+    </row>
+    <row>
+     <entry><link linkend="ini.syslog.filter">syslog.filter</link></entry>
+     <entry>"no-ctrl"</entry>
+     <entry>PHP_INI_ALL</entry>
+     <entry>Disponível a partir do PHP 7.3.0.</entry>
+    </row>
+    <row>
+     <entry><link linkend="ini.syslog.ident">syslog.ident</link></entry>
+     <entry>"php"</entry>
+     <entry>PHP_INI_SYSTEM</entry>
+     <entry>Disponível a partir do PHP 7.3.0.</entry>
+    </row>
     </tbody>
    </tgroup>
   </table>
@@ -135,54 +153,68 @@
     </term>
     <listitem>
      <para>
-      Set the error reporting level. The parameter is either an integer
-      representing a bit field, or named constants. The error_reporting
-      levels and constants are described in
-      <link linkend="errorfunc.constants">Predefined Constants</link>,
-      and in &php.ini;. To set at runtime, use the
-      <function>error_reporting</function> function. See also the
-      <link linkend="ini.display-errors">display_errors</link> directive.
+      Define o nível de relatório de erros. O parâmetro é ou um inteiro
+      representando um campo de bits ou constantes nomeadas. Os níveis e
+      constantes de error_reporting são descritos em
+      <link linkend="errorfunc.constants">Constantes Pré-definidas</link> e no
+      arquivo &php.ini;. Para definir em tempo de execução, use a função
+      <function>error_reporting</function>. Veja também a diretiva
+      <link linkend="ini.display-errors">display_errors</link>.
      </para>
      <para>
-      In PHP 4 and PHP 5 the default value is <constant>E_ALL</constant>
+      A partir do PHP 5.3, o valor padrão
+      é <constant>E_ALL</constant> &amp;
+      ~<constant>E_NOTICE</constant> &amp;
+      ~<constant>E_STRICT</constant> &amp;
+      ~<constant>E_DEPRECATED</constant>. Esta configuração não mostra os níveis
+      de erro <constant>E_NOTICE</constant>, <constant>E_STRICT</constant>
+      e <constant>E_DEPRECATED</constant>. Você pode querer
+      mostrá-los durante o desenvolvimento.
+      Antes do PHP 5.3.0, o valor padrão
+      é <constant>E_ALL</constant> &amp;
+      ~<constant>E_NOTICE</constant> &amp;
+      ~<constant>E_STRICT</constant>.
+      No PHP 4, o valor padrão é <constant>E_ALL</constant>
       &amp; ~<constant>E_NOTICE</constant>.
-      This setting does not show <constant>E_NOTICE</constant> level errors. You
-      may want to show them during development.
      </para>
      <note>
-      <para>Enabling <constant>E_NOTICE</constant> during development has
-      some benefits. For debugging purposes: NOTICE messages will warn you
-      about possible bugs in your code. For example, use of unassigned values
-      is warned. It is extremely useful to find typos and
-      to save time for debugging. NOTICE messages will warn you about bad style.
-      For example, <literal>$arr[item]</literal> is better to be written as
-      <literal>$arr['item']</literal> since PHP tries to treat
-      <literal>"item"</literal> as constant. If it is not a constant, PHP assumes
-      it is a string index for the array.
+      <para>Habilitar o <constant>E_NOTICE</constant> durante o desenvolvimento
+      traz alguns benefícios. Para fins de depuração: as mensagens NOTICE irão
+      avisá-lo sobre possíveis erros em seu código. Por exemplo, o uso de
+      valores não atribuídos é avisado. É extremamente útil para encontrar erros
+      de digitação e para economizar tempo de depuração. As mensagens NOTICE
+      irão avisá-lo sobre estilo ruim. Por exemplo, <literal>$arr[item]</literal>
+      é melhor ser escrito como <literal>$arr['item']</literal> já que o PHP
+      tenta tratar <literal>"item"</literal> como constante. Se não for uma
+      constante, o PHP assume que é uma string para o índice do array.
       </para>
      </note>
      <note>
       <para>
-       In PHP 5 a new error level <constant>E_STRICT</constant> is available.
-       As <constant>E_STRICT</constant> is not included within
-       <constant>E_ALL</constant> you have to explicitly enable this kind of
-       error level. Enabling <constant>E_STRICT</constant> during development
-       has some benefits. STRICT messages will help you to use the latest and
-       greatest suggested method of coding, for example warn you about using
-       deprecated functions.
+       No PHP 5, um novo nível de erro <constant>E_STRICT</constant> está disponível.
+       Antes do PHP 5.4.0, <constant>E_STRICT</constant> não estava incluído no
+       <constant>E_ALL</constant>, portanto, você teria que habilitar explicitamente esse tipo de
+       nível de erro no PHP &lt; 5.4.0. Habilitar o <constant>E_STRICT</constant> durante o desenvolvimento
+       traz alguns benefícios. As mensagens STRICT fornecem sugestões que podem
+       ajudar a garantir a melhor interoperabilidade e compatibilidade futura do
+       seu código. Essas mensagens podem incluir coisas como chamar estaticamente
+       métodos não-estáticos, definir propriedades em uma definição de classe
+       compatível enquanto estiver definido em um trait usado e, antes do PHP 5.3,
+       alguns recursos descontinuados emitiriam erros <constant>E_STRICT</constant>,
+       como atribuir objetos por referência na instanciação.
       </para>
      </note>
      <note>
-      <title>PHP Constants outside of PHP</title>
+      <title>Constantes do PHP fora do PHP</title>
       <para>
-       Using PHP Constants outside of PHP, like in <filename>httpd.conf</filename>,
-       will have no useful meaning so in such cases the <type>integer</type> values 
-       are required. And since error levels will be added over time, the maximum
-       value (for <constant>E_ALL</constant>) will likely change. So in place of
-       <constant>E_ALL</constant> consider using a larger value to cover all bit
-       fields from now and well into the future, a numeric value like
-       <literal>2147483647</literal> (includes all errors, not just
-       <constant>E_ALL</constant>).
+       Usar constantes do PHP fora do PHP, como no <filename>httpd.conf</filename>,
+       não terão significado algum, portanto, nesses casos, os valores <type>integer</type>
+       são necessários. E, como níveis de erro serão adicionados ao longo do tempo,
+       o valor máximo (para <constant>E_ALL</constant>) provavelmente será alterado.
+       Portanto, no lugar de <constant>E_ALL</constant>, considere usar um valor
+       maior para cobrir todos os campos de bits tanto os de hoje como os do futuro,
+       um valor numérico como <literal>2147483647</literal> (inclui todos os
+       erros, não apenas <constant>E_ALL</constant>).
       </para>
      </note>
     </listitem>
@@ -195,25 +227,25 @@
     </term>
     <listitem>
      <para>
-      This determines whether errors should be printed to the screen
-      as part of the output or if they should be hidden from the user.
+      Isso determina se os erros devem ser impressos na tela
+      como parte da saída ou se devem ser ocultados do usuário.
      </para>
      <para>
-      Value <literal>"stderr"</literal> sends the errors to <literal>stderr</literal>
-      instead of <literal>stdout</literal>. The value is available as of PHP
-      5.2.4. In earlier versions, this directive was of type <type>boolean</type>.
+      O valor <literal>"stderr"</literal> envia os erros para <literal>stderr</literal>
+      em vez de <literal>stdout</literal>. O valor está disponível a partir do
+      PHP 5.2.4. Em versões anteriores, essa diretiva era do tipo <type>boolean</type>.
      </para>
      <note>
       <para>
-      This is a feature to support your development and should never be used 
-      on production systems (e.g. systems connected to the internet).
+      Este é um recurso para dar suporte ao seu desenvolvimento e nunca deve ser
+      usado em sistemas de produção (por exemplo, sistemas conectados à internet).
       </para>
      </note>
      <note>
       <para>
-       Although display_errors may be set at runtime (with <function>ini_set</function>),
-       it won't have any affect if the script has fatal errors.
-       This is because the desired runtime action does not get executed.
+       Embora display_errors possa ser configurado em tempo de execução (com <function>ini_set</function>),
+       ele não terá nenhum efeito se o script tiver erros fatais.
+       Isso ocorre porque a ação em tempo de execução desejada não é executada.
       </para>
      </note>
     </listitem>
@@ -226,9 +258,9 @@
     </term>
     <listitem>
      <para>
-      Even when display_errors is on, errors that occur during PHP's startup
-      sequence are not displayed. It's strongly recommended to keep
-      display_startup_errors off, except for debugging.
+      Mesmo quando display_errors está ativado, erros que ocorrem durante a
+      sequência de inicialização do PHP não são exibidos. É altamente
+      recomendável manter display_startup_errors desativado, exceto para depuração.
      </para>
     </listitem>
    </varlistentry>
@@ -240,14 +272,14 @@
     </term>
     <listitem>
      <para>
-      Tells whether script error messages should be logged to the
-      server's error log or <link linkend="ini.error-log">error_log</link>.
-      This option is thus server-specific.
+      Informa se as mensagens de erro de script devem ser registradas no log de
+      erros do servidor ou no <link linkend="ini.error-log">error_log</link>.
+      Essa opção é, portanto, específica do servidor.
      </para>
      <note>
       <para>
-       You're strongly advised to use error logging in place of
-       error displaying on production web sites.
+       É altamente recomendável usar o registro de erros em vez de
+       exibir erros em sites de produção.
       </para>
      </note>
     </listitem>
@@ -260,12 +292,13 @@
     </term>
     <listitem>
      <para>
-      Set the maximum length of log_errors in bytes. In
-      <link linkend="ini.error-log">error_log</link> information about
-      the source is added. The default is 1024 and 0 allows to not apply
-      any maximum length at all.
-      This length is applied to logged errors, displayed errors and also to
-      <varname>$php_errormsg</varname>.
+      Define o comprimento máximo de log_errors em bytes. Em
+      <link linkend="ini.error-log">error_log</link>, informações sobre a
+      fonte são adicionadas. O padrão é 1024 e 0 não aplica um
+      comprimento máximo.
+      Esse tamanho é aplicado a erros registrados, erros exibidos e também a
+      <varname>$php_errormsg</varname>, mas não à funções chamadas
+      explicitamente como <function>error_log</function>.
      </para>
 
      &ini.shorthandbytes;
@@ -280,10 +313,10 @@
     </term>
     <listitem>
      <para>
-      Do not log repeated messages. Repeated errors must occur in the same
-      file on the same line unless
+      Não registrar mensagens repetidas. Erros repetidos devem ocorrer no mesmo
+      arquivo e na mesma linha, a menos que
       <link linkend="ini.ignore-repeated-source">ignore_repeated_source</link>
-      is set true.
+      seja definido como verdadeiro.
      </para>
     </listitem>
    </varlistentry>
@@ -295,9 +328,9 @@
     </term>
     <listitem>
      <para>
-      Ignore source of message when ignoring repeated messages. When this setting
-      is On you will not log errors with repeated messages from different files or
-      sourcelines.
+      Ignora a fonte da mensagem quando estiver ignorando mensagens repetidas.
+      Quando esta configuração estiver On, você não registrará erros com
+      mensagens repetidas de arquivos ou linhas diferentes.
      </para>
     </listitem>
    </varlistentry>
@@ -309,14 +342,14 @@
     </term>
     <listitem>
      <para>
-      If this parameter is set to On (the default), this parameter will show a
-      report of memory leaks detected by the Zend memory manager. This report
-      will be send to stderr on Posix platforms. On Windows, it will be send
-      to the debugger using OutputDebugString(), and can be viewed with tools
-      like <link xlink:href="&url.dbgview;">DbgView</link>.
-      This parameter only has effect in a debug build, and if
-      error_reporting includes <constant>E_WARNING</constant> in the allowed
-      list.
+      Se este parâmetro estiver definido como On (o padrão), este parâmetro
+      mostrará um relatório de vazamentos de memória detectados pelo gerenciador
+      de memória do Zend. Este relatório será enviado para stderr em plataformas
+      Posix. No Windows, ele será enviado ao depurador usando o
+      OutputDebugString() e poderá ser visualizado com ferramentas como o
+      <link xlink:href="&url.dbgview;">DbgView</link>. Este parâmetro só tem
+      efeito em uma compilação de depuração, e se error_reporting incluir
+      <constant>E_WARNING</constant> na lista de permitidos.
      </para>
     </listitem>
    </varlistentry>
@@ -328,8 +361,8 @@
     </term>
     <listitem>
      <para>
-      If enabled, the last error message will always be present in the
-      variable <varname>$php_errormsg</varname>.
+      Se habilitado, a última mensagem de erro estará sempre presente na
+      variável <varname>$php_errormsg</varname>.
      </para>
     </listitem>
    </varlistentry>
@@ -341,12 +374,15 @@
     </term>
     <listitem>
      <para>
-      Turn off HTML tags in error messages. The new format for HTML errors
-      produces clickable messages that direct the user to a page describing
-      the error or function in causing the error. These references are
-      affected by
-      <link linkend="ini.docref-root">docref_root</link> and
+      Se ativado, as mensagens de erro incluirão tags HTML. O formato para erros
+      de HTML produz mensagens clicáveis que direcionam o usuário para uma
+      página descrevendo o erro ou a função que está causando o erro. Essas
+      referências são afetadas por
+      <link linkend="ini.docref-root">docref_root</link> e
       <link linkend="ini.docref-ext">docref_ext</link>.
+     </para>
+     <para>
+      Se desativado, a mensagem de erro será apenas texto simples.
      </para>
     </listitem>
    </varlistentry>
@@ -358,7 +394,8 @@
     </term>
     <listitem>
      <para>
-      Turns off normal error reporting and formats errors as XML-RPC error message.
+      Se ativado, desativa o relatório de erros normal e formata os erros como
+      mensagem de erro XML-RPC.
      </para>
     </listitem>
    </varlistentry>
@@ -370,7 +407,7 @@
     </term>
     <listitem>
      <para>
-      Used as the value of the XML-RPC faultCode element.
+      Usado como o valor do elemento faultCode do XML-RPC.
      </para>
     </listitem>
    </varlistentry>
@@ -382,27 +419,27 @@
     </term>
     <listitem>
      <para>
-      The new error format contains a reference to a page describing the error or 
-      function causing the error. In case of manual pages you can download the 
-      manual in your language and set this ini directive to the URL of your local
-      copy. If your local copy of the manual can be reached by <literal>"/manual/"</literal>
-      you can simply use <userinput>docref_root=/manual/</userinput>. Additional you have 
-      to set docref_ext to match the fileextensions of your copy 
-      <userinput>docref_ext=.html</userinput>. It is possible to use external 
-      references. For example you can use 
-      <userinput>docref_root=http://manual/en/</userinput> or
+      O novo formato de erro contém uma referência a uma página que descreve o erro
+      ou a função que está causando o erro. No caso de páginas de manual, você pode
+      baixar o manual em seu idioma e definir esta diretiva ini para a URL da sua cópia
+      local. Se a sua cópia local do manual pode ser alcançada por <literal>"/manual/"</literal>
+      você pode simplesmente usar <userinput>docref_root=/manual/</userinput>. Além disso,
+      você precisa definir docref_ext para corresponder às extensões de arquivo de sua cópia
+      <userinput>docref_ext=.html</userinput>. É possível usar referências
+      externas. Por exemplo, você pode usar
+      <userinput>docref_root=http://manual/en/</userinput> ou
       <userinput>docref_root="http://landonize.it/?how=url&amp;theme=classic&amp;filter=Landon
       &amp;url=http%3A%2F%2Fwww.php.net%2F"</userinput>
      </para>
      <para>
-      Most of the time you want the docref_root value to end with a slash <literal>"/"</literal>.
-      But see the second example above which does not have nor need it.
+      Na maioria das vezes, você quer que o valor docref_root termine com uma barra
+      <literal>"/"</literal>. Mas veja o segundo exemplo acima, que não tem nem precisa dela.
      </para>
      <note>
       <para>
-       This is a feature to support your development since it makes it easy to 
-       lookup a function description. However it should never be used on 
-       production systems (e.g. systems connected to the internet).
+       Este é um recurso para dar suporte ao seu desenvolvimento, pois facilita
+       a pesquisa da descrição de uma função. No entanto, nunca deve ser usado
+       em sistemas de produção (por exemplo, sistemas conectados à internet).
       </para>
      </note>
     </listitem>
@@ -415,11 +452,11 @@
     </term>
     <listitem>
      <para>
-      See <link linkend="ini.docref-root">docref_root</link>.
+      Veja <link linkend="ini.docref-root">docref_root</link>.
      </para>
      <note>
       <para>
-       The value of docref_ext must begin with a dot <literal>"."</literal>.
+       O valor de docref_ext deve começar com um ponto <literal>"."</literal>.
       </para>
      </note>
     </listitem>
@@ -432,7 +469,7 @@
     </term>
     <listitem>
      <para>
-      String to output before an error message.
+      String para mostrar antes de uma mensagem de erro.
      </para>
     </listitem>
    </varlistentry>
@@ -444,7 +481,7 @@
     </term>
     <listitem>
      <para>
-      String to output after an error message.
+      String para mostrar após uma mensagem de erro.
      </para>
     </listitem>
    </varlistentry>
@@ -456,16 +493,69 @@
     </term>
     <listitem>
      <para>
-      Name of the file where script errors should be logged. The file should
-      be writable by the web server's user. If the
-      special value <literal>syslog</literal> is used, the errors
-      are sent to the system logger instead. On Unix, this means
-      syslog(3) and on Windows NT it means the event log. The
-      system logger is not supported on Windows 95. See also:
+      Nome do arquivo onde os erros de script devem ser registrados. O arquivo
+      deve ter permissão de escrita pelo usuário do servidor da web. Se o valor
+      especial <literal>syslog</literal> for usado, os erros serão enviados ao
+      registrador de erros do sistema. No Unix, isso significa syslog(3) e no
+      Windows significa o log de eventos. Veja também:
       <function>syslog</function>.
-      If this directive is not set, errors are sent to the SAPI error logger. 
-      For example, it is an error log in Apache or <literal>stderr</literal>
-      in CLI.
+      Se esta diretiva não estiver definida, os erros serão enviados para o
+      registrador de erros SAPI.
+      Por exemplo, é um log de erros no Apache ou <literal>stderr</literal>
+      no CLI. Veja também <function>error_log</function>.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="ini.syslog.facility">
+    <term>
+     <parameter>syslog.facility</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <para>
+      Especifica qual tipo de programa está registrando a mensagem. Somente é
+      efetivo se <link linkend="ini.error-log">error_log</link> estiver definido como "syslog".
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="ini.syslog.filter">
+    <term>
+     <parameter>syslog.filter</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <para>
+      Especifica o tipo de filtro para filtrar as mensagens registradas.
+      Caracteres permitidos são passados sem modificações; todos os outros são
+      escritos em sua representação hexadecimal prefixado com
+      <literal>\x</literal>. Existem três tipos de filtros suportados:
+      <itemizedlist>
+       <listitem>
+        <simpara><literal>all</literal> – todos os caracteres</simpara>
+       </listitem>
+       <listitem>
+        <simpara><literal>no-ctrl</literal> – todos os caracteres, exceto os caracteres de controle</simpara>
+       </listitem>
+       <listitem>
+        <simpara><literal>ascii</literal> – todos os caracteres ASCII imprimíveis e <literal>NL</literal></simpara>
+       </listitem>
+      </itemizedlist>
+      Somente é efetivo se <link linkend="ini.error-log">error_log</link> estiver definido como "syslog".
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="ini.syslog.ident">
+    <term>
+     <parameter>syslog.ident</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <para>
+      Especifica a string ident que é anexada a todas as mensagens.
+      Somente é efetivo se <link linkend="ini.error-log">error_log</link> estiver definido como "syslog".
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Conserta o erro de validação do manual:

```
 IDREF attribute linkend references an unknown ID "ini.syslog.filter"
 IDREF attribute linkend references an unknown ID "ini.syslog.facility"
 IDREF attribute linkend references an unknown ID "ini.syslog.ident"
```