### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: php
+
+before_script:
+  - svn checkout --quiet https://svn.php.net/repository/phpdoc/doc-base/trunk doc-base
+  - svn checkout --quiet https://svn.php.net/repository/phpdoc/en/trunk en
+
+script:
+  - php doc-base/configure.php --enable-xml-details --disable-libxml-check --redirect-stderr-to-stdout --with-lang=pt_BR


### PR DESCRIPTION
Adiciona suporte para o teste `php doc-base/configure.php` através do Travis CI.

Dessa forma é possível saber de antemão se um pull request passou no teste ou não.

Pode ver um exemplo aqui:
https://travis-ci.org/mauriciofauth/phpdocbr/builds/543287454#L262